### PR TITLE
Fix XXE test when running without XML support

### DIFF
--- a/src/tests/disable_xxe_dom.phpt
+++ b/src/tests/disable_xxe_dom.phpt
@@ -2,8 +2,11 @@
 Disable XXE
 --SKIPIF--
 <?php
- if (!extension_loaded("snuffleupagus")) die "skip";
- if (!extension_loaded("dom")) die "skip";
+ if (!extension_loaded("snuffleupagus")) {
+  echo "skip"; 
+} elseif (!extension_loaded("dom")) {
+	echo "skip";
+}
  ?>
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini

--- a/src/tests/disable_xxe_dom_disabled.phpt
+++ b/src/tests/disable_xxe_dom_disabled.phpt
@@ -2,8 +2,8 @@
 Disable XXE
 --SKIPIF--
 <?php
- if (!extension_loaded("snuffleupagus")) die "skip";
- if (!extension_loaded("dom")) die "skip";
+ if (!extension_loaded("snuffleupagus")) echo "skip";
+ if (!extension_loaded("dom")) echo "skip";
  ?>
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe_disable.ini

--- a/src/tests/disable_xxe_simplexml.phpt
+++ b/src/tests/disable_xxe_simplexml.phpt
@@ -2,8 +2,8 @@
 Disable XXE
 --SKIPIF--
 <?php
- if (!extension_loaded("snuffleupagus")) die "skip";
- if (!extension_loaded("simplexml")) die "skip";
+ if (!extension_loaded("snuffleupagus")) echo "skip";
+ if (!extension_loaded("simplexml")) echo "skip";
  ?>
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini

--- a/src/tests/disable_xxe_simplexml_oop.phpt
+++ b/src/tests/disable_xxe_simplexml_oop.phpt
@@ -2,8 +2,8 @@
 Disable XXE
 --SKIPIF--
 <?php
- if (!extension_loaded("snuffleupagus")) die "skip";
- if (!extension_loaded("simplexml")) die "skip";
+ if (!extension_loaded("snuffleupagus")) echo "skip";
+ if (!extension_loaded("simplexml")) echo "skip";
  ?>
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini

--- a/src/tests/disable_xxe_xml_parse.phpt
+++ b/src/tests/disable_xxe_xml_parse.phpt
@@ -1,9 +1,12 @@
 --TEST--
-Disable XXE
+Disable XXE in xml_parse
 --SKIPIF--
 <?php
- if (!extension_loaded("snuffleupagus")) die "skip";
- if (!extension_loaded("xml")) die "skip";
+ if (!extension_loaded("snuffleupagus")) {
+  echo "skip because snuffleupagus isn't loaded";
+} elseif (!extension_loaded("xml")) {
+  echo "skip because the `xml` extension isn't loaded";
+}
  ?>
 --INI--
 sp.configuration_file={PWD}/config/disable_xxe.ini


### PR DESCRIPTION
Apparently, using `echo` instead of `die` works better™

Please to test this locally, since the testsuite is already running fine on travis-ci, but some people have issues while running it on their workstations.