### PR TITLE
Fix two cookie encryption issues found by @cfreal, and a bonus one

### DIFF
--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -59,7 +59,7 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
     return ZEND_HASH_APPLY_KEEP;
   }
 
-  debase64 = php_base64_decode_ex((unsigned char *)(Z_STRVAL_P(pDest)), value_len, 1);
+  debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)), value_len);
 
   if (NULL == debase64) {
     goto fail;

--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -61,10 +61,6 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
 
   debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)), value_len);
 
-  if (NULL == debase64) {
-    goto fail;
-  }
-
   if (ZSTR_LEN(debase64) <
       crypto_secretbox_NONCEBYTES + crypto_secretbox_ZEROBYTES) {
     sp_log_msg("cookie_encryption", SP_LOG_DROP,
@@ -81,7 +77,6 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
       (unsigned char *)ZSTR_VAL(debase64), key);
 
   if (ret == -1) {
-fail:
     sp_log_msg("cookie_encryption", SP_LOG_DROP,
       "Something went wrong with the decryption of %s.",
                ZSTR_VAL(hash_key->key));


### PR DESCRIPTION
- Use the base64-decoded payload length to allocate memory to decrypt
  it, instead of allocating the length of the undecoded one. This has
  no security impact, since the base64-encoded string is at least as large
  as the decoded one. Since we're using AEAD, there is no way to leak
  memory, since this would make the decryption fail.
- Use `php_base64_decode_ex` instead of `php_base64_decode`, since the
  later can't be configured to choke on invalid characters.
- Fix a possible NULL-deref when trying to decode invalid base64 decoding