### PR TITLE
Implement match on arguments position

### DIFF
--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -77,6 +77,7 @@ typedef struct {
   char *param;
   pcre *r_param;
   sp_php_type param_type;
+  int pos;
 
   char *ret;
   pcre *r_ret;
@@ -183,6 +184,7 @@ typedef struct {
 #define SP_TOKEN_RET_TYPE ".ret_type("
 #define SP_TOKEN_VALUE ".value("
 #define SP_TOKEN_VALUE_REGEXP ".value_r("
+#define SP_TOKEN_VALUE_ARG_POS ".pos("
 
 // cookies encryption
 #define SP_TOKEN_NAME ".cookie("

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -237,7 +237,14 @@ int parse_disabled_functions(char *line) {
   }
 
   if (pos) {
-    df->pos = atoi(pos) > 128 ? 128: atoi(pos); // FIXME do the strtol dance
+    errno = 0;
+    df->pos = strtol(pos, NULL, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    if (errno != 0) {
+      sp_log_err("config",
+		 "Failed to parse arg '%s' of `pos` on line %zu.",
+		 pos, sp_line_no);
+      return -1;
+    }
   }
 
   if (df->function) {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -238,8 +238,9 @@ int parse_disabled_functions(char *line) {
 
   if (pos) {
     errno = 0;
-    df->pos = strtol(pos, NULL, 10) > 128 ? 128 : strtol(pos, NULL, 10);
-    if (errno != 0) {
+    char *endptr;
+    df->pos = strtol(pos, &endptr, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    if (errno != 0 || endptr == pos) {
       sp_log_err("config",
 		 "Failed to parse arg '%s' of `pos` on line %zu.",
 		 pos, sp_line_no);

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -239,12 +239,16 @@ int parse_disabled_functions(char *line) {
   if (pos) {
     errno = 0;
     char *endptr;
-    df->pos = strtol(pos, &endptr, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    df->pos = strtol(pos, &endptr, 10);
     if (errno != 0 || endptr == pos) {
-      sp_log_err("config",
-		 "Failed to parse arg '%s' of `pos` on line %zu.",
-		 pos, sp_line_no);
+      sp_log_err("config", "Failed to parse arg '%s' of `pos` on line %zu.",
+		    pos, sp_line_no);
       return -1;
+    }
+
+    // We'll never have a function with more than 128 params
+    if (df->pos > 128) {
+      df->pos = 128;
     }
   }
 

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -144,7 +144,9 @@ int parse_cookie_encryption(char *line) {
 int parse_disabled_functions(char *line) {
   int ret = 0;
   bool enable = true, disable = false;
+  char *pos = NULL;
   sp_disabled_function *df = pecalloc(sizeof(*df), 1, 1);
+  df->pos = -1;
 
   sp_config_functions sp_config_funcs_disabled_functions[] = {
       {parse_empty, SP_TOKEN_ENABLE, &(enable)},
@@ -169,6 +171,7 @@ int parse_disabled_functions(char *line) {
       {parse_regexp, SP_TOKEN_RET_REGEXP, &(df->r_ret)},
       {parse_php_type, SP_TOKEN_RET_TYPE, &(df->ret_type)},
       {parse_str, SP_TOKEN_LOCAL_VAR, &(df->var)},
+      {parse_str, SP_TOKEN_VALUE_ARG_POS, &(pos)},
       {0}};
 
   ret = parse_keywords(sp_config_funcs_disabled_functions, line);
@@ -231,6 +234,10 @@ int parse_disabled_functions(char *line) {
                "rule must either be a `drop` or and `allow` one on line %zu.",
                line, sp_line_no);
     return -1;
+  }
+
+  if (pos) {
+    df->pos = atoi(pos) > 128 ? 128: atoi(pos); // FIXME do the strtol dance
   }
 
   if (df->function) {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -204,10 +204,10 @@ int parse_disabled_functions(char *line) {
                "'.r_filename' and '.filename' are mutually exclusive on line %zu.",
                line, sp_line_no);
     return -1;
-  } else if (df->r_param && df->param) {
+  } else if (1 < ((df->r_param?1:0) + (df->param?1:0) + ((-1 != df->pos)?1:0))) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s':"
-               "'.r_param' and '.param' are mutually exclusive on line %zu.",
+               "'.r_param', '.param' and '.pos' are mutually exclusive on line %zu.",
                line, sp_line_no);
     return -1;
   } else if (df->r_ret && df->ret) {

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -178,11 +178,17 @@ bool should_disable(zend_execute_data* execute_data) {
     }
 
     /* Check if we filter on parameter value*/
-    if (config_node->param || config_node->r_param) {
-      const unsigned int nb_param = execute_data->func->common.num_args;
+    if (config_node->param || config_node->r_param || (config_node->pos != -1)) {
+      unsigned int nb_param = execute_data->func->common.num_args;
       bool arg_matched = false;
+      int i = 0;
 
-      for (unsigned int i = 0; i < nb_param; i++) {
+      if (config_node->pos != -1) {//&& nb_param <= config_node->pos) {
+        i = config_node->pos;
+        nb_param = (config_node->pos) + 1;
+      }
+
+      for (; i < nb_param; i++) {
         arg_matched = false;
         if (ZEND_USER_CODE(execute_data->func->type)) {  // yay consistency
           arg_name = ZSTR_VAL(execute_data->func->common.arg_info[i].name);
@@ -197,7 +203,7 @@ bool should_disable(zend_execute_data* execute_data) {
             (true == is_regexp_matching(config_node->r_param, arg_name));
 
         /* This is the parameter name we're looking for. */
-        if (true == arg_matching || true == pcre_matching) {
+        if (true == arg_matching || true == pcre_matching || (config_node->pos != -1)) {
           zval* arg_value = ZEND_CALL_VAR_NUM(execute_data, i);
 
           if (config_node->param_type) {  // Are we matching on the `type`?

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -183,7 +183,7 @@ bool should_disable(zend_execute_data* execute_data) {
       bool arg_matched = false;
       int i = 0;
 
-      if (config_node->pos != -1) {//&& nb_param <= config_node->pos) {
+      if ((config_node->pos != -1) && (config_node->pos <= nb_param)) {
         i = config_node->pos;
         nb_param = (config_node->pos) + 1;
       }

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -179,7 +179,7 @@ bool should_disable(zend_execute_data* execute_data) {
 
     /* Check if we filter on parameter value*/
     if (config_node->param || config_node->r_param || (config_node->pos != -1)) {
-      unsigned int nb_param = execute_data->func->common.num_args;
+      int nb_param = execute_data->func->common.num_args;
       bool arg_matched = false;
       int i = 0;
 

--- a/src/tests/broken_conf_mutually_exclusive4.phpt
+++ b/src/tests/broken_conf_mutually_exclusive4.phpt
@@ -6,4 +6,4 @@ Broken configuration
 sp.configuration_file={PWD}/config/broken_conf_mutually_exclusive4.ini
 --FILE--
 --EXPECT--
-[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").param("id").value("42").param_r("^id$").drop();':'.r_param' and '.param' are mutually exclusive on line 1.
+[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").param("id").value("42").param_r("^id$").drop();':'.r_param', '.param' and '.pos' are mutually exclusive on line 1.

--- a/src/tests/config/disabled_functions_invalid_pos.ini
+++ b/src/tests/config/disabled_functions_invalid_pos.ini
@@ -1,1 +1,1 @@
-sp.disable_functions.function("system").pos("qwe").value("id").drop();
+sp.disable_function.function("system").pos("qwe").value("id").drop();

--- a/src/tests/config/disabled_functions_invalid_pos.ini
+++ b/src/tests/config/disabled_functions_invalid_pos.ini
@@ -1,0 +1,1 @@
+sp.disable_functions.function("system").pos("qwe").value("id").drop();

--- a/src/tests/config/disabled_functions_pos.ini
+++ b/src/tests/config/disabled_functions_pos.ini
@@ -1,1 +1,1 @@
-sp.disable_functions.function("system").pos("0").value("id").drop();
+sp.disable_function.function("system").pos("0").value("id").drop();

--- a/src/tests/config/disabled_functions_pos.ini
+++ b/src/tests/config/disabled_functions_pos.ini
@@ -1,0 +1,1 @@
+sp.disable_functions.function("system").pos("0").value("id").drop();

--- a/src/tests/disabled_functions_param_invalid_pos.phpt
+++ b/src/tests/disabled_functions_param_invalid_pos.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Disable functions - match on argument's position
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_invalid_pos.ini
+--FILE--
+<?php 
+system("echo 1");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][config][error] Failed to parse arg 'qwe' of `pos` on line 1.
+1
+

--- a/src/tests/disabled_functions_param_pos.phpt
+++ b/src/tests/disabled_functions_param_pos.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Disable functions - match on argument's position
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_pos.ini
+--FILE--
+<?php 
+system("id");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param_pos.php:%d has been disabled, because its argument 'command' content (id) matched a rule.


### PR DESCRIPTION
`strtol` is dreaful to use. Is there anything else that we could use instead?