### PR TITLE
bailout implementation

### DIFF
--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -358,7 +358,7 @@ ZEND_FUNCTION(check_disabled_function) {
   const char* current_function_name = get_active_function_name(TSRMLS_C);
 
   if (true == should_disable(execute_data)) {
-    return;
+    zend_bailout();
   }
 
   if ((orig_handler = zend_hash_str_find_ptr(

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -358,7 +358,7 @@ ZEND_FUNCTION(check_disabled_function) {
   const char* current_function_name = get_active_function_name(TSRMLS_C);
 
   if (true == should_disable(execute_data)) {
-    zend_bailout();
+    sp_terminate();
   }
 
   if ((orig_handler = zend_hash_str_find_ptr(
@@ -366,7 +366,7 @@ ZEND_FUNCTION(check_disabled_function) {
            strlen(current_function_name)))) {
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     if (true == should_drop_on_ret(return_value, execute_data)) {
-      zend_bailout();
+      sp_terminate();
     }
   } else {
     sp_log_err(

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,8 +51,8 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  }
-
+  } else
+    sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -64,7 +64,8 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  }
+  } else
+    sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
 
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,8 +51,9 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -64,9 +65,9 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
-
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -28,7 +28,7 @@ PHP_FUNCTION(sp_serialize) {
               SNUFFLEUPAGUS_G(config).config_snuffleupagus->encryption_key);
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 3, params);
 
-  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac) + 1;
+  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac);
   zend_string *res = zend_string_alloc(len, 0);
 
   memcpy(ZSTR_VAL(res), Z_STRVAL_P(return_value), Z_STRLEN_P(return_value));

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -13,6 +13,7 @@ PHP_FUNCTION(sp_serialize) {
     sp_log_err("disabled_functions",
         "Unable to find the pointer to the original function 'serialize' in "
         "the hashtable.\n");
+    return;
   }
 
   /* Compute the HMAC of the textual representation of the serialized data*/
@@ -27,7 +28,7 @@ PHP_FUNCTION(sp_serialize) {
               SNUFFLEUPAGUS_G(config).config_snuffleupagus->encryption_key);
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 3, params);
 
-  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac);
+  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac) + 1;
   zend_string *res = zend_string_alloc(len, 0);
 
   memcpy(ZSTR_VAL(res), Z_STRVAL_P(return_value), Z_STRLEN_P(return_value));

--- a/src/tests/disabled_functions.phpt
+++ b/src/tests/disabled_functions.phpt
@@ -13,9 +13,5 @@ var_dump("this is a super test");
 echo strpos("pouet", "o");
 ?>
 --EXPECTF--
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'printf' in %a/tests/disabled_functions.php:%d has been disabled.
-printf in simulation mode
-print in disabled mode
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'var_dump' in %a/tests/disabled_functions.php:%d has been disabled.
-1
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions.php:2 has been disabled.
+

--- a/src/tests/disabled_functions_cidr.phpt
+++ b/src/tests/disabled_functions_cidr.phpt
@@ -11,8 +11,6 @@ sp.configuration_file={PWD}/config/disabled_functions_cidr.ini
 --FILE--
 <?php
 system("echo 42");
-printf("1337");
 ?>
 --EXPECTF--
 [snuffleupagus][127.0.0.1][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_cidr.php:2 has been disabled.
-1337

--- a/src/tests/disabled_functions_cidr_6.phpt
+++ b/src/tests/disabled_functions_cidr_6.phpt
@@ -15,4 +15,3 @@ printf(1337);
 ?>
 --EXPECTF--
 [snuffleupagus][2001:0db8:0000:0000:0000:ff00:0042:8328][disabled_function][drop] The call to the function 'strpos' in %a/tests/disabled_functions_cidr_6.php:2 has been disabled.
-1337

--- a/src/tests/disabled_functions_namespace.phpt
+++ b/src/tests/disabled_functions_namespace.phpt
@@ -28,6 +28,3 @@ my_function();
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'strcmp' in %a/disabled_functions_namespace.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'my_super_namespace\my_function' in %a/disabled_functions_namespace.php:%d has been disabled.
-Second namespace
-Anonymous namespace

--- a/src/tests/disabled_functions_nul_byte.phpt
+++ b/src/tests/disabled_functions_nul_byte.phpt
@@ -12,4 +12,3 @@ system("id");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_nul_byte.php:2 has been disabled, because its argument 'command' content (0id) matched a rule.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_nul_byte.php:3 has been disabled, because its argument 'command' content (id) matched a rule.

--- a/src/tests/disabled_functions_param.phpt
+++ b/src/tests/disabled_functions_param.phpt
@@ -16,9 +16,3 @@ strncmp("bla", "ble", 2);
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param.php:2 has been disabled, because its argument 'command' content (id) matched the rule '1'.
-win
-int(15)
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'shell_exec' in %a/disabled_functions_param.php:5 has been disabled, because its argument 'cmd' content (id) matched the rule '3'.
-42
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'strcmp' in %a/tests/disabled_functions_param.php:7 has been disabled, because its argument 'str1' content (bla) matched the rule '5'.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'strncmp' in %a/tests/disabled_functions_param.php:8 has been disabled, because its argument 'str1' content (bla) matched a rule.

--- a/src/tests/disabled_functions_param_alias.phpt
+++ b/src/tests/disabled_functions_param_alias.phpt
@@ -11,4 +11,3 @@ shell_exec("id");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_param_alias.php:2 has been disabled, because of the the rule '1'.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'shell_exec' in %a/tests/disabled_functions_param_alias.php:3 has been disabled, because of the the rule '2'.

--- a/src/tests/disabled_functions_param_r.phpt
+++ b/src/tests/disabled_functions_param_r.phpt
@@ -11,4 +11,3 @@ system("echo win");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_param_r.php:2 has been disabled, because its argument 'command' content (id) matched a rule.
-win

--- a/src/tests/disabled_functions_upper.phpt
+++ b/src/tests/disabled_functions_upper.phpt
@@ -14,8 +14,3 @@ echo sTRPOs("pouet", "o");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'printf' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-printf in simulation mode
-print in disabled mode
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'var_dump' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-1

--- a/src/tests/disabled_functions_zero_cidr.phpt
+++ b/src/tests/disabled_functions_zero_cidr.phpt
@@ -15,4 +15,3 @@ printf("1337");
 ?>
 --EXPECTF--
 [snuffleupagus][127.0.0.1][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_zero_cidr.php:2 has been disabled.
-1337

--- a/src/tests/dump_request_invalid_folder.phpt
+++ b/src/tests/dump_request_invalid_folder.phpt
@@ -23,4 +23,3 @@ echo "2\n";
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %atests/dump_request_invalid_folder.php:3 has been disabled.
 [snuffleupagus][0.0.0.0][request_logging][error] Unable to create the folder '/root/NON_EXISTENT/FOLDER/PLEASE/'.
 [snuffleupagus][0.0.0.0][request_logging][error] Unable to open /root/NON_EXISTENT/FOLDER/PLEASE/sp_dump_%a_0.0.0.0.dump
-2


### PR DESCRIPTION

 - Change `.drop()` behavior. Don't just nop the call, instead we are now calling `zend_bailout()`, terminating script execution.
 - Log a message if rand/mt_rand function pointers failed to be found.

 