### PR TITLE
drop is bailout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ after_success:
       ./lcov/bin/genhtml -o ./COV.html ./COV.info  --branch-coverage ;
       coveralls --exclude "tweetnacl.c" ;
     fi'
-  - cd ..
-  - make joomla
 
 after_failure:
   - grep -r . ./tests/*.out

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -6,6 +6,9 @@ Snuffleupagus is using its own format in the file specified by
 the directive ``sp.configuration_file`` (in your ``php.ini`` file),
 like ``sp.configuration_file=/etc/php/conf.d/snuffleupagus.ini``.
 
+You can use the ``,`` separator to include multiple configuration files :
+``sp.configuration_file=/etc/php/conf.d/snuffleupagus.ini,/etc/php/conf.d/sp_wordpress.ini``
+
 Options are chainable by using dots (``.``) and string parameters
 **must** be quoted, while booleans and integers aren't.
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -237,6 +237,7 @@ Filters
 - ``function(name)``: match on function ``name``
 - ``function_r(regexp)``: the function matching the ``regexp``
 - ``hash(sha256)``: match on the file's `sha256 <https://en.wikipedia.org/wiki/SHA-2>`_ sum
+- ``line(line_number)``: match on the file's line.
 - ``param(name)``: match on the function's parameter ``name``
 - ``param_r(regexp)``: match on the function's parameter ``regexp``
 - ``param_type(type)``: match on the function's parameter ``type``

--- a/doc/source/papers.rst
+++ b/doc/source/papers.rst
@@ -1,13 +1,13 @@
 Propaganda
 ==========
 
-This pages lists various mentions, articles and presentations about Snuffleupagus.
+This pages lists various mentions, articles, usages and presentations about Snuffleupagus.
 
 Talks
 -----
 
-- `BerlinSide0x08 <https://berlinsides.org/?page_id=2168>`_ - `Php7 Nightmares <slides.pdf>`_ - 2017-05-28
-- `Hack.lu 2017 <https://2017.hack.lu/talks/>`_ - `Killing bugclasses in PHP 7, virtual-patching the rest <https://github.com/nbs-system/snuffleupagus/blob/master/slides/hacklu_2017.pdf>`_ - 2017-10-18
+- `BerlinSide0x08 <https://berlinsides.org/?page_id=2168>`_ - `slides <https://dustri.org/b/killing-php-bug-classes-at-berlinsides.html>`__ - 2017-05-28
+- `Hack.lu 2017 <https://2017.hack.lu/talks/>`_ - `slides <https://github.com/nbs-system/snuffleupagus/blob/master/slides/hacklu_2017.pdf>`__ - `video <https://www.youtube.com/watch?v=RzaRiuJ6MkI>`__ - 2017-10-18
 - `BlackAlps <https://blackalps.ch/2017program.php>`_ - soon™ - 2017-11-16
 
 Articles
@@ -15,3 +15,10 @@ Articles
 
 - `Killing php bug classes at berlinsides <https://dustri.org/b/killing-php-bug-classes-at-berlinsides.html>`_ - 2017-06-05
 - `Snuffleu…what? <https://fr33tux.org/post/snuffleupagus/>`_ - 2017-10-07
+
+
+Notable users
+-------------
+
+- `Toolslib <https://toolslib.net/>`__ - an `Alexa top 10k <https://www.alexa.com/siteinfo/toolslib.net>`__ website
+- `AdwCleaner <https://www.malwarebytes.com/adwcleaner/>`__'s backend- a notorious anti-pup

--- a/doc/source/papers.rst
+++ b/doc/source/papers.rst
@@ -7,7 +7,7 @@ Talks
 -----
 
 - `BerlinSide0x08 <https://berlinsides.org/?page_id=2168>`_ - `Php7 Nightmares <slides.pdf>`_ - 2017-05-28
-- `Hack.lu <https://2017.hack.lu/talks/>`_ - soon™ - 2017-10-18
+- `Hack.lu 2017 <https://2017.hack.lu/talks/>`_ - `Killing bugclasses in PHP 7, virtual-patching the rest <https://github.com/nbs-system/snuffleupagus/blob/master/slides/hacklu_2017.pdf>`_ - 2017-10-18
 - `BlackAlps <https://blackalps.ch/2017program.php>`_ - soon™ - 2017-11-16
 
 Articles

--- a/src/snuffleupagus.c
+++ b/src/snuffleupagus.c
@@ -154,12 +154,20 @@ PHP_MINFO_FUNCTION(snuffleupagus) {
 static PHP_INI_MH(OnUpdateConfiguration) {
   TSRMLS_FETCH();
 
+  char *config_file = NULL;
+
   if (!new_value || !new_value->len) {
     return FAILURE;
   }
 
-  if (sp_parse_config(new_value->val) != SUCCESS) {
+  config_file = strtok(new_value->val, ",");
+  if (sp_parse_config(config_file) != SUCCESS) {
     return FAILURE;
+  }
+  while ((config_file = strtok(NULL, ","))) {
+    if (sp_parse_config(config_file) != SUCCESS) {
+      return FAILURE;
+    }
   }
 
   if (SNUFFLEUPAGUS_G(config).config_random->enable) {

--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -72,7 +72,6 @@ typedef struct {
 
   char *hash;
   int simulation;
-  bool enable;
 
   char *param;
   pcre *r_param;

--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -78,6 +78,7 @@ typedef struct {
   pcre *r_param;
   sp_php_type param_type;
   int pos;
+  unsigned int line;
 
   char *ret;
   pcre *r_ret;
@@ -185,6 +186,7 @@ typedef struct {
 #define SP_TOKEN_VALUE ".value("
 #define SP_TOKEN_VALUE_REGEXP ".value_r("
 #define SP_TOKEN_VALUE_ARG_POS ".pos("
+#define SP_TOKEN_LINE_NUMBER ".line("
 
 // cookies encryption
 #define SP_TOKEN_NAME ".cookie("

--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -77,6 +77,7 @@ typedef struct {
   char *param;
   pcre *r_param;
   sp_php_type param_type;
+  int pos;
 
   char *ret;
   pcre *r_ret;
@@ -183,6 +184,7 @@ typedef struct {
 #define SP_TOKEN_RET_TYPE ".ret_type("
 #define SP_TOKEN_VALUE ".value("
 #define SP_TOKEN_VALUE_REGEXP ".value_r("
+#define SP_TOKEN_VALUE_ARG_POS ".pos("
 
 // cookies encryption
 #define SP_TOKEN_NAME ".cookie("

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -237,7 +237,14 @@ int parse_disabled_functions(char *line) {
   }
 
   if (pos) {
-    df->pos = atoi(pos) > 128 ? 128: atoi(pos); // FIXME do the strtol dance
+    errno = 0;
+    df->pos = strtol(pos, NULL, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    if (errno != 0) {
+      sp_log_err("config",
+		 "Failed to parse arg '%s' of `pos` on line %zu.",
+		 pos, sp_line_no);
+      return -1;
+    }
   }
 
   if (df->function) {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -238,8 +238,9 @@ int parse_disabled_functions(char *line) {
 
   if (pos) {
     errno = 0;
-    df->pos = strtol(pos, NULL, 10) > 128 ? 128 : strtol(pos, NULL, 10);
-    if (errno != 0) {
+    char *endptr;
+    df->pos = strtol(pos, &endptr, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    if (errno != 0 || endptr == pos) {
       sp_log_err("config",
 		 "Failed to parse arg '%s' of `pos` on line %zu.",
 		 pos, sp_line_no);

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -239,12 +239,16 @@ int parse_disabled_functions(char *line) {
   if (pos) {
     errno = 0;
     char *endptr;
-    df->pos = strtol(pos, &endptr, 10) > 128 ? 128 : strtol(pos, NULL, 10);
+    df->pos = strtol(pos, &endptr, 10);
     if (errno != 0 || endptr == pos) {
-      sp_log_err("config",
-		 "Failed to parse arg '%s' of `pos` on line %zu.",
-		 pos, sp_line_no);
+      sp_log_err("config", "Failed to parse arg '%s' of `pos` on line %zu.",
+		    pos, sp_line_no);
       return -1;
+    }
+
+    // We'll never have a function with more than 128 params
+    if (df->pos > 128) {
+      df->pos = 128;
     }
   }
 

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -144,7 +144,9 @@ int parse_cookie_encryption(char *line) {
 int parse_disabled_functions(char *line) {
   int ret = 0;
   bool enable = true, disable = false;
+  char *pos = NULL;
   sp_disabled_function *df = pecalloc(sizeof(*df), 1, 1);
+  df->pos = -1;
 
   sp_config_functions sp_config_funcs_disabled_functions[] = {
       {parse_empty, SP_TOKEN_ENABLE, &(enable)},
@@ -169,6 +171,7 @@ int parse_disabled_functions(char *line) {
       {parse_regexp, SP_TOKEN_RET_REGEXP, &(df->r_ret)},
       {parse_php_type, SP_TOKEN_RET_TYPE, &(df->ret_type)},
       {parse_str, SP_TOKEN_LOCAL_VAR, &(df->var)},
+      {parse_str, SP_TOKEN_VALUE_ARG_POS, &(pos)},
       {0}};
 
   ret = parse_keywords(sp_config_funcs_disabled_functions, line);
@@ -231,6 +234,10 @@ int parse_disabled_functions(char *line) {
                "rule must either be a `drop` or and `allow` one on line %zu.",
                line, sp_line_no);
     return -1;
+  }
+
+  if (pos) {
+    df->pos = atoi(pos) > 128 ? 128: atoi(pos); // FIXME do the strtol dance
   }
 
   if (df->function) {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -145,6 +145,7 @@ int parse_disabled_functions(char *line) {
   int ret = 0;
   bool enable = true, disable = false;
   char *pos = NULL;
+  char *line_number = NULL;
   sp_disabled_function *df = pecalloc(sizeof(*df), 1, 1);
   df->pos = -1;
 
@@ -172,6 +173,7 @@ int parse_disabled_functions(char *line) {
       {parse_php_type, SP_TOKEN_RET_TYPE, &(df->ret_type)},
       {parse_str, SP_TOKEN_LOCAL_VAR, &(df->var)},
       {parse_str, SP_TOKEN_VALUE_ARG_POS, &(pos)},
+      {parse_str, SP_TOKEN_LINE_NUMBER, &(line_number)},
       {0}};
 
   ret = parse_keywords(sp_config_funcs_disabled_functions, line);
@@ -249,6 +251,17 @@ int parse_disabled_functions(char *line) {
     // We'll never have a function with more than 128 params
     if (df->pos > 128) {
       df->pos = 128;
+    }
+  }
+
+  if (line_number) {
+    errno = 0;
+    char *endptr;
+    df->line = strtoul(line_number, &endptr, 10);
+    if (errno != 0 || endptr == line_number) {
+      sp_log_err("config", "Failed to parse arg '%s' of `line` on line %zu.",
+		 line_number, sp_line_no);
+      return -1;
     }
   }
 

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -204,10 +204,10 @@ int parse_disabled_functions(char *line) {
                "'.r_filename' and '.filename' are mutually exclusive on line %zu.",
                line, sp_line_no);
     return -1;
-  } else if (df->r_param && df->param) {
+  } else if (1 < ((df->r_param?1:0) + (df->param?1:0) + ((-1 != df->pos)?1:0))) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s':"
-               "'.r_param' and '.param' are mutually exclusive on line %zu.",
+               "'.r_param', '.param' and '.pos' are mutually exclusive on line %zu.",
                line, sp_line_no);
     return -1;
   } else if (df->r_ret && df->ret) {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -182,12 +182,6 @@ int parse_disabled_functions(char *line) {
     return ret;
   }
 
-  if (true == disable){
-    df->enable = false;
-  } else {
-    df->enable = true;
-  }
-
   if (df->value && df->value_r) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s':"
@@ -294,6 +288,10 @@ int parse_disabled_functions(char *line) {
     case ZEND_ECHO:
     default:
       break;
+  }
+
+  if (true == disable) {
+    return ret;
   }
 
   if (df->ret || df->r_ret || df->ret_type) {

--- a/src/sp_config_utils.c
+++ b/src/sp_config_utils.c
@@ -2,9 +2,7 @@
 
 size_t sp_line_no;
 
-static int validate_str(const char *value);
-
-static sp_pure int validate_str(const char *value) {
+static int validate_str(const char *value) {
   int balance = 0;  // ghetto [] validation
 
   if (!strchr(value, '[')) {
@@ -18,6 +16,7 @@ static sp_pure int validate_str(const char *value) {
       balance--;
     }
     if (balance < 0) {
+      sp_log_err("config", "The string '%s' contains unbalanced brackets.", value);
       return -1;
     }
   }

--- a/src/sp_config_utils.c
+++ b/src/sp_config_utils.c
@@ -107,9 +107,13 @@ static char *get_string(size_t *consumed, char *restrict line,
     ret[j++] = line[i];
   }
 err:
-  sp_log_err("error",
-             "There is an issue with the parsing of '%s': it doesn't look like a valid string on line %zu.",
-             original_line ? original_line : "NULL", sp_line_no);
+  if (0 == j) {
+    sp_log_err("error", "A valid string as parameter is expected on line %zu.", sp_line_no);
+  } else {
+    sp_log_err("error",
+               "There is an issue with the parsing of '%s': it doesn't look like a valid string on line %zu.",
+               original_line ? original_line : "NULL", sp_line_no);
+}
   line = NULL;
   return NULL;
 }

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -178,11 +178,17 @@ bool should_disable(zend_execute_data* execute_data) {
     }
 
     /* Check if we filter on parameter value*/
-    if (config_node->param || config_node->r_param) {
-      const unsigned int nb_param = execute_data->func->common.num_args;
+    if (config_node->param || config_node->r_param || (config_node->pos != -1)) {
+      unsigned int nb_param = execute_data->func->common.num_args;
       bool arg_matched = false;
+      int i = 0;
 
-      for (unsigned int i = 0; i < nb_param; i++) {
+      if (config_node->pos != -1) {//&& nb_param <= config_node->pos) {
+        i = config_node->pos;
+        nb_param = (config_node->pos) + 1;
+      }
+
+      for (; i < nb_param; i++) {
         arg_matched = false;
         if (ZEND_USER_CODE(execute_data->func->type)) {  // yay consistency
           arg_name = ZSTR_VAL(execute_data->func->common.arg_info[i].name);
@@ -197,7 +203,7 @@ bool should_disable(zend_execute_data* execute_data) {
             (true == is_regexp_matching(config_node->r_param, arg_name));
 
         /* This is the parameter name we're looking for. */
-        if (true == arg_matching || true == pcre_matching) {
+        if (true == arg_matching || true == pcre_matching || (config_node->pos != -1)) {
           zval* arg_value = ZEND_CALL_VAR_NUM(execute_data, i);
 
           if (config_node->param_type) {  // Are we matching on the `type`?

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -172,6 +172,12 @@ bool should_disable(zend_execute_data* execute_data) {
       }
     }
 
+    if (config_node->line) {
+      if (config_node->line != zend_get_executed_lineno()) {
+	goto next;
+      }
+    }
+
     if (client_ip && config_node->cidr &&
         (false == cidr_match(client_ip, config_node->cidr))) {
       goto next;

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -183,7 +183,7 @@ bool should_disable(zend_execute_data* execute_data) {
       bool arg_matched = false;
       int i = 0;
 
-      if (config_node->pos != -1) {//&& nb_param <= config_node->pos) {
+      if ((config_node->pos != -1) && (config_node->pos <= nb_param)) {
         i = config_node->pos;
         nb_param = (config_node->pos) + 1;
       }

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -358,7 +358,7 @@ ZEND_FUNCTION(check_disabled_function) {
   const char* current_function_name = get_active_function_name(TSRMLS_C);
 
   if (true == should_disable(execute_data)) {
-    return;
+    zend_bailout();
   }
 
   if ((orig_handler = zend_hash_str_find_ptr(

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -179,7 +179,7 @@ bool should_disable(zend_execute_data* execute_data) {
 
     /* Check if we filter on parameter value*/
     if (config_node->param || config_node->r_param || (config_node->pos != -1)) {
-      unsigned int nb_param = execute_data->func->common.num_args;
+      int nb_param = execute_data->func->common.num_args;
       bool arg_matched = false;
       int i = 0;
 

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -358,7 +358,7 @@ ZEND_FUNCTION(check_disabled_function) {
   const char* current_function_name = get_active_function_name(TSRMLS_C);
 
   if (true == should_disable(execute_data)) {
-    zend_bailout();
+    sp_terminate();
   }
 
   if ((orig_handler = zend_hash_str_find_ptr(
@@ -366,7 +366,7 @@ ZEND_FUNCTION(check_disabled_function) {
            strlen(current_function_name)))) {
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
     if (true == should_drop_on_ret(return_value, execute_data)) {
-      zend_bailout();
+      sp_terminate();
     }
   } else {
     sp_log_err(

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -57,6 +57,7 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
   }
 
   if (true == should_disable(execute_data)) {
+    sp_terminate();
     return;
   }
 

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,8 +51,8 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  }
-
+  } else
+    sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -64,7 +64,8 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  }
+  } else
+    sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
 
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,8 +51,9 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -64,9 +65,9 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
-
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,8 +51,9 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -64,8 +65,9 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else
+  } else {
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
+  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -51,9 +51,8 @@ PHP_FUNCTION(sp_rand) {
     /* call the original `rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else {
+  } else
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'rand' in the hashtable.\n");
-  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 
@@ -65,9 +64,8 @@ PHP_FUNCTION(sp_mt_rand) {
     /* call the original `mt_rand` function,
      * since we might no be the only ones to hook it*/
     orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-  } else {
+  } else
     sp_log_err("harden_rand", "Unable to find the pointer to the original function 'mt_rand' in the hashtable.\n");
-  }
   random_int_wrapper(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -28,7 +28,7 @@ PHP_FUNCTION(sp_serialize) {
               SNUFFLEUPAGUS_G(config).config_snuffleupagus->encryption_key);
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 3, params);
 
-  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac) + 1;
+  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac);
   zend_string *res = zend_string_alloc(len, 0);
 
   memcpy(ZSTR_VAL(res), Z_STRVAL_P(return_value), Z_STRLEN_P(return_value));

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -28,7 +28,7 @@ PHP_FUNCTION(sp_serialize) {
               SNUFFLEUPAGUS_G(config).config_snuffleupagus->encryption_key);
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 3, params);
 
-  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac);
+  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac) + 1;
   zend_string *res = zend_string_alloc(len, 0);
 
   memcpy(ZSTR_VAL(res), Z_STRVAL_P(return_value), Z_STRLEN_P(return_value));

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -13,6 +13,7 @@ PHP_FUNCTION(sp_serialize) {
     sp_log_err("disabled_functions",
         "Unable to find the pointer to the original function 'serialize' in "
         "the hashtable.\n");
+    return;
   }
 
   /* Compute the HMAC of the textual representation of the serialized data*/
@@ -27,7 +28,7 @@ PHP_FUNCTION(sp_serialize) {
               SNUFFLEUPAGUS_G(config).config_snuffleupagus->encryption_key);
   call_user_function(CG(function_table), NULL, &func_name, &hmac, 3, params);
 
-  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac);
+  size_t len = Z_STRLEN_P(return_value) + Z_STRLEN(hmac) + 1;
   zend_string *res = zend_string_alloc(len, 0);
 
   memcpy(ZSTR_VAL(res), Z_STRVAL_P(return_value), Z_STRLEN_P(return_value));

--- a/src/sp_upload_validation.c
+++ b/src/sp_upload_validation.c
@@ -79,7 +79,7 @@ int sp_rfc1867_callback(unsigned int event, void *event_data, void **extra) {
       if (WEXITSTATUS(waitstatus) != 0) {  // Nope
         char *uri = sp_getenv("REQUEST_URI");
         int sim = SNUFFLEUPAGUS_G(config).config_upload_validation->simulation;
-        sp_log_msg("upload_valiation", sim?SP_LOG_SIMULATION:SP_LOG_DROP,
+        sp_log_msg("upload_validation", sim?SP_LOG_SIMULATION:SP_LOG_DROP,
           "The upload of %s on %s was rejected.", filename, uri?uri:"?");
         if (!SNUFFLEUPAGUS_G(config).config_upload_validation->simulation) {
           zend_bailout();

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -42,11 +42,8 @@ zend_always_inline int is_regexp_matching(const pcre* regexp, const char* str) {
   int vec[30];
   int ret = 0;
 
-  if (!regexp || !str) {
-    sp_log_err("regexp", "Something went wrong with a regexp (%d:%d).",
-     !regexp?0:1, !str?0:1);
-    return false;
-  }
+  assert(NULL != regexp);
+  assert(NULL != str);
 
   ret = sp_pcre_exec(regexp, NULL, str, strlen(str), 0, 0, vec,
    sizeof(vec)/sizeof(int));

--- a/src/tests/broken_conf_invalid_cidr_value.phpt
+++ b/src/tests/broken_conf_invalid_cidr_value.phpt
@@ -7,5 +7,5 @@ Broken configuration, invalid cidr value
 sp.configuration_file={PWD}/config/broken_conf_invalid_cidr_value.ini
 --FILE--
 --EXPECT--
-[snuffleupagus][0.0.0.0][error][error] There is an issue with the parsing of '"': it doesn't look like a valid string on line 1.
+[snuffleupagus][0.0.0.0][error][error] A valid string as parameter is expected on line 1.
 [snuffleupagus][0.0.0.0][config][error] " doesn't contain a valid cidr on line 1.

--- a/src/tests/broken_conf_line_empty_string.phpt
+++ b/src/tests/broken_conf_line_empty_string.phpt
@@ -6,4 +6,4 @@ Configuration line with an empty string
 sp.configuration_file={PWD}/config/broken_conf_line_empty_string.ini
 --FILE--
 --EXPECT--
-[snuffleupagus][0.0.0.0][error][error] There is an issue with the parsing of '': it doesn't look like a valid string on line 1.
+[snuffleupagus][0.0.0.0][error][error] A valid string as parameter is expected on line 1.

--- a/src/tests/broken_conf_mutually_exclusive4.phpt
+++ b/src/tests/broken_conf_mutually_exclusive4.phpt
@@ -6,4 +6,4 @@ Broken configuration
 sp.configuration_file={PWD}/config/broken_conf_mutually_exclusive4.ini
 --FILE--
 --EXPECT--
-[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").param("id").value("42").param_r("^id$").drop();':'.r_param' and '.param' are mutually exclusive on line 1.
+[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").param("id").value("42").param_r("^id$").drop();':'.r_param', '.param' and '.pos' are mutually exclusive on line 1.

--- a/src/tests/broken_unmatching_brackets.phpt
+++ b/src/tests/broken_unmatching_brackets.phpt
@@ -1,0 +1,9 @@
+--TEST--
+Broken configuration - unmatching brackets
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_unmatching_brackets.ini
+--FILE--
+--EXPECTF--
+[snuffleupagus][0.0.0.0][config][error] The string 'arr[b]]]]]' contains unbalanced brackets.

--- a/src/tests/config/config_disabled_functions_chain_call_user_func.ini
+++ b/src/tests/config/config_disabled_functions_chain_call_user_func.ini
@@ -1,0 +1,2 @@
+sp.disable_function.function("outer>call_user_func>inner").simulation().drop();
+sp.disable_function.function("outer>inner").drop();

--- a/src/tests/config/config_disabled_functions_param_r.ini
+++ b/src/tests/config/config_disabled_functions_param_r.ini
@@ -1,1 +1,2 @@
+sp.disable_function.function("system").param_r("^not_command$").value("id").drop();
 sp.disable_function.function("system").param_r("^command$").value("id").drop();

--- a/src/tests/config/config_multi1.ini
+++ b/src/tests/config/config_multi1.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("foo").simulation().drop();

--- a/src/tests/config/config_multi2.ini
+++ b/src/tests/config/config_multi2.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("bla").simulation().drop();

--- a/src/tests/config/config_unmatching_brackets.ini
+++ b/src/tests/config/config_unmatching_brackets.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("foo").param("arr[b]]]]]").value("aaa").alias("4").drop();

--- a/src/tests/config/disabled_functions.ini
+++ b/src/tests/config/disabled_functions.ini
@@ -5,3 +5,4 @@ sp.disable_function.function("printf").simulation().drop();
 sp.disable_function.function("print").disable().drop();  # this is a comment
 sp.disable_function.function_r("^var_dump$").drop();
 sp.disable_function.function("sprintf").filename("wrong file name").drop();
+sp.disable_function.function("eval").drop();

--- a/src/tests/config/disabled_functions_broken_line.ini
+++ b/src/tests/config/disabled_functions_broken_line.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("system").line("qwe").drop();

--- a/src/tests/config/disabled_functions_cidr.ini
+++ b/src/tests/config/disabled_functions_cidr.ini
@@ -1,3 +1,4 @@
+sp.disable_function.function("system").drop().cidr("192.168.0.1/16");
 sp.disable_function.function("system").drop().cidr("127.0.0.1/8");
 sp.disable_function.function("printf").drop().cidr("10.0.0.1/8");
 sp.disable_function.function("strpos").drop().cidr("2001:0db8:0000:0000:0000:ff00:0042:8329/24");

--- a/src/tests/config/disabled_functions_invalid_pos.ini
+++ b/src/tests/config/disabled_functions_invalid_pos.ini
@@ -1,1 +1,1 @@
-sp.disable_functions.function("system").pos("qwe").value("id").drop();
+sp.disable_function.function("system").pos("qwe").value("id").drop();

--- a/src/tests/config/disabled_functions_invalid_pos.ini
+++ b/src/tests/config/disabled_functions_invalid_pos.ini
@@ -1,0 +1,1 @@
+sp.disable_functions.function("system").pos("qwe").value("id").drop();

--- a/src/tests/config/disabled_functions_line.ini
+++ b/src/tests/config/disabled_functions_line.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("system").line("3").drop();

--- a/src/tests/config/disabled_functions_pos.ini
+++ b/src/tests/config/disabled_functions_pos.ini
@@ -1,1 +1,1 @@
-sp.disable_functions.function("system").pos("0").value("id").drop();
+sp.disable_function.function("system").pos("0").value("id").drop();

--- a/src/tests/config/disabled_functions_pos.ini
+++ b/src/tests/config/disabled_functions_pos.ini
@@ -1,0 +1,1 @@
+sp.disable_functions.function("system").pos("0").value("id").drop();

--- a/src/tests/config/disabled_functions_pos.ini
+++ b/src/tests/config/disabled_functions_pos.ini
@@ -1,1 +1,2 @@
+sp.disable_function.function("system").pos("1337").value("id").drop();
 sp.disable_function.function("system").pos("0").value("id").drop();

--- a/src/tests/config/disabled_functions_ret.ini
+++ b/src/tests/config/disabled_functions_ret.ini
@@ -1,4 +1,5 @@
 sp.disable_function.function("testFunction").ret("0").drop().disable();
+sp.disable_function.function("strpos").ret("0").drop().filename_r(".*\\.not_matching");
 sp.disable_function.function("strpos").ret("0").drop().filename_r(".*\\.php");
 sp.disable_function.function_r("str[ia]pos").ret_r("^[^a-z]+$").drop();
 sp.disable_function.function_r("stripos").ret_r("^[^a-z]+").drop();

--- a/src/tests/config/disabled_functions_retval_dump.ini
+++ b/src/tests/config/disabled_functions_retval_dump.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("str_repeat").ret("fufufu").drop().dump("/tmp/dump_result/");

--- a/src/tests/disabled_functions.phpt
+++ b/src/tests/disabled_functions.phpt
@@ -13,9 +13,5 @@ var_dump("this is a super test");
 echo strpos("pouet", "o");
 ?>
 --EXPECTF--
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'printf' in %a/tests/disabled_functions.php:%d has been disabled.
-printf in simulation mode
-print in disabled mode
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'var_dump' in %a/tests/disabled_functions.php:%d has been disabled.
-1
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions.php:2 has been disabled.
+

--- a/src/tests/disabled_functions_chain.phpt
+++ b/src/tests/disabled_functions_chain.phpt
@@ -24,5 +24,4 @@ echo "I'm after the call to outer\n";
 I'm before the call to outer
 I'm in the outer function, before the call!
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'outer>inner' in %a/disabled_functions_chain.php:%d has been disabled.
-I'm in the outer function, after the call!
-I'm after the call to outer
+

--- a/src/tests/disabled_functions_chain_call_user_func.phpt
+++ b/src/tests/disabled_functions_chain_call_user_func.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Disable functions by matching the calltrace, with call_user_func involved
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_disabled_functions_chain_call_user_func.ini
+--FILE--
+<?php 
+
+function outer() {
+    function inner() {
+        echo "I'm in the inner function!\n";
+    }
+    echo "I'm in the outer function, before the call!\n";
+    call_user_func("inner");
+    echo "I'm in the outer function, after the call!\n";
+}
+
+echo "I'm before the call to outer\n";
+outer();
+echo "I'm after the call to outer\n";
+?>
+--EXPECTF--
+I'm before the call to outer
+I'm in the outer function, before the call!
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'outer>inner' in %a/disabled_functions_chain_call_user_func.php:%d has been disabled.
+I'm in the outer function, after the call!
+I'm after the call to outer

--- a/src/tests/disabled_functions_chain_call_user_func.phpt
+++ b/src/tests/disabled_functions_chain_call_user_func.phpt
@@ -24,5 +24,3 @@ echo "I'm after the call to outer\n";
 I'm before the call to outer
 I'm in the outer function, before the call!
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'outer>inner' in %a/disabled_functions_chain_call_user_func.php:%d has been disabled.
-I'm in the outer function, after the call!
-I'm after the call to outer

--- a/src/tests/disabled_functions_cidr.phpt
+++ b/src/tests/disabled_functions_cidr.phpt
@@ -11,8 +11,6 @@ sp.configuration_file={PWD}/config/disabled_functions_cidr.ini
 --FILE--
 <?php
 system("echo 42");
-printf("1337");
 ?>
 --EXPECTF--
 [snuffleupagus][127.0.0.1][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_cidr.php:2 has been disabled.
-1337

--- a/src/tests/disabled_functions_cidr_6.phpt
+++ b/src/tests/disabled_functions_cidr_6.phpt
@@ -15,4 +15,3 @@ printf(1337);
 ?>
 --EXPECTF--
 [snuffleupagus][2001:0db8:0000:0000:0000:ff00:0042:8328][disabled_function][drop] The call to the function 'strpos' in %a/tests/disabled_functions_cidr_6.php:2 has been disabled.
-1337

--- a/src/tests/disabled_functions_eval.phpt
+++ b/src/tests/disabled_functions_eval.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Disable functions - eval
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions.ini
+--XFAIL--
+--FILE--
+<?php 
+$var = 1234;
+eval('$var = 1337;');
+print("Variable: $var\n");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'eval' in %a/tests/disabled_functions_eval.php:%d has been disabled, because it matched a rule.

--- a/src/tests/disabled_functions_method.phpt
+++ b/src/tests/disabled_functions_method.phpt
@@ -25,5 +25,3 @@ $c->method3("pouet");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'AwesomeClass::method1' in %a/tests/disabled_functions_method.php:4 has been disabled.
-method2:paf
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'AwesomeClass::method3' in %a/tests/disabled_functions_method.php:10 has been disabled, because its argument 'a' content (pouet) matched a rule.

--- a/src/tests/disabled_functions_namespace.phpt
+++ b/src/tests/disabled_functions_namespace.phpt
@@ -28,6 +28,3 @@ my_function();
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'strcmp' in %a/disabled_functions_namespace.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'my_super_namespace\my_function' in %a/disabled_functions_namespace.php:%d has been disabled.
-Second namespace
-Anonymous namespace

--- a/src/tests/disabled_functions_nul_byte.phpt
+++ b/src/tests/disabled_functions_nul_byte.phpt
@@ -12,4 +12,3 @@ system("id");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_nul_byte.php:2 has been disabled, because its argument 'command' content (0id) matched a rule.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_nul_byte.php:3 has been disabled, because its argument 'command' content (id) matched a rule.

--- a/src/tests/disabled_functions_param.phpt
+++ b/src/tests/disabled_functions_param.phpt
@@ -16,9 +16,3 @@ strncmp("bla", "ble", 2);
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param.php:2 has been disabled, because its argument 'command' content (id) matched the rule '1'.
-win
-int(15)
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'shell_exec' in %a/disabled_functions_param.php:5 has been disabled, because its argument 'cmd' content (id) matched the rule '3'.
-42
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'strcmp' in %a/tests/disabled_functions_param.php:7 has been disabled, because its argument 'str1' content (bla) matched the rule '5'.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'strncmp' in %a/tests/disabled_functions_param.php:8 has been disabled, because its argument 'str1' content (bla) matched a rule.

--- a/src/tests/disabled_functions_param_alias.phpt
+++ b/src/tests/disabled_functions_param_alias.phpt
@@ -11,4 +11,3 @@ shell_exec("id");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_param_alias.php:2 has been disabled, because of the the rule '1'.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'shell_exec' in %a/tests/disabled_functions_param_alias.php:3 has been disabled, because of the the rule '2'.

--- a/src/tests/disabled_functions_param_array.phpt
+++ b/src/tests/disabled_functions_param_array.phpt
@@ -29,9 +29,3 @@ foo($a);
 --EXPECTF--
 test1
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foo' in %a/disabled_functions_param_array.php:3 has been disabled, because its argument 'arr' content (Array) matched the rule '1'.
-abcde
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foo' in %a/disabled_functions_param_array.php:3 has been disabled, because its argument 'arr' content (Array) matched the rule '2'.
-eee
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foo' in %a/disabled_functions_param_array.php:3 has been disabled, because its argument 'arr' content (Array) matched the rule '3'.
-cccc
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foo' in %a/disabled_functions_param_array.php:3 has been disabled, because its argument 'arr' content (Array) matched the rule '4'.

--- a/src/tests/disabled_functions_param_broken_line.phpt
+++ b/src/tests/disabled_functions_param_broken_line.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Disable functions - match on a specific line - broken configuration
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_broken_line.ini
+--FILE--
+<?php 
+system("echo 1337");
+system("echo 1338");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][config][error] Failed to parse arg 'qwe' of `line` on line 1.
+1337
+1338

--- a/src/tests/disabled_functions_param_int.phpt
+++ b/src/tests/disabled_functions_param_int.phpt
@@ -19,7 +19,3 @@ foobar("10");
 --EXPECTF--
 1
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foobar' in %a/tests/disabled_functions_param_int.php:3 has been disabled, because its argument 'id' content (42) matched a rule.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foobar' in %a/tests/disabled_functions_param_int.php:3 has been disabled, because its argument 'id' content (1337) matched a rule.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foobar' in %a/tests/disabled_functions_param_int.php:3 has been disabled, because its argument 'id' content (13374242) matched a rule.
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'foobar' in %a/tests/disabled_functions_param_int.php:3 has been disabled, because its argument 'id' content (42) matched a rule.
-10

--- a/src/tests/disabled_functions_param_invalid_pos.phpt
+++ b/src/tests/disabled_functions_param_invalid_pos.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Disable functions - match on argument's position
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_invalid_pos.ini
+--FILE--
+<?php 
+system("echo 1");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][config][error] Failed to parse arg 'qwe' of `pos` on line 1.
+1
+

--- a/src/tests/disabled_functions_param_line.phpt
+++ b/src/tests/disabled_functions_param_line.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Disable functions - match on a specific line
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_line.ini
+--FILE--
+<?php 
+system("echo 1337");
+system("id");
+?>
+--EXPECTF--
+1337
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param_line.php:3 has been disabled.

--- a/src/tests/disabled_functions_param_pos.phpt
+++ b/src/tests/disabled_functions_param_pos.phpt
@@ -9,4 +9,5 @@ sp.configuration_file={PWD}/config/disabled_functions_pos.ini
 system("id");
 ?>
 --EXPECTF--
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param_pos.php:%d has been disabled, because its argument 'command' content (id) matched a rule.
+[snuffleupagus][0.0.0.0][config][error] It seems that you wrote a rule filtering on the 0th argument of the function 'system', but it takes only 2 arguments. Matching on _all_ arguments instead.
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param_pos.php:2 has been disabled, because its argument 'command' content (id) matched a rule.

--- a/src/tests/disabled_functions_param_pos.phpt
+++ b/src/tests/disabled_functions_param_pos.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Disable functions - match on argument's position
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_pos.ini
+--FILE--
+<?php 
+system("id");
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/disabled_functions_param_pos.php:%d has been disabled, because its argument 'command' content (id) matched a rule.

--- a/src/tests/disabled_functions_param_r.phpt
+++ b/src/tests/disabled_functions_param_r.phpt
@@ -11,4 +11,3 @@ system("echo win");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_param_r.php:2 has been disabled, because its argument 'command' content (id) matched a rule.
-win

--- a/src/tests/disabled_functions_ret_val_dump.phpt
+++ b/src/tests/disabled_functions_ret_val_dump.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Disable functions ret val - dump
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_functions_retval_dump.ini
+--POST--
+post_a=data_post_a&post_b=data_post_b
+--GET--
+get_a=data_get_a&get_b=data_get_b
+--COOKIE--
+cookie_a=data_cookie_a&cookie_b=data_cookie_b
+--FILE--
+<?php 
+echo str_repeat("fufu",1)."\n";
+echo str_repeat("fufufu",1);
+?>
+--EXPECTF--
+fufu
+[snuffleupagus][0.0.0.0][disabled_function][drop] The execution has been aborted in %a/disabled_functions_ret_val_dump.php:%d, because the return value (fufufu) of the function 'str_repeat' matched a rule.

--- a/src/tests/disabled_functions_upper.phpt
+++ b/src/tests/disabled_functions_upper.phpt
@@ -14,8 +14,3 @@ echo sTRPOs("pouet", "o");
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'printf' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-printf in simulation mode
-print in disabled mode
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'var_dump' in %a/tests/disabled_functions_upper.php:%d has been disabled.
-1

--- a/src/tests/disabled_functions_zero_cidr.phpt
+++ b/src/tests/disabled_functions_zero_cidr.phpt
@@ -15,4 +15,3 @@ printf("1337");
 ?>
 --EXPECTF--
 [snuffleupagus][127.0.0.1][disabled_function][drop] The call to the function 'system' in %a/tests/disabled_functions_zero_cidr.php:2 has been disabled.
-1337

--- a/src/tests/dump_request_invalid_folder.phpt
+++ b/src/tests/dump_request_invalid_folder.phpt
@@ -23,4 +23,3 @@ echo "2\n";
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'system' in %atests/dump_request_invalid_folder.php:3 has been disabled.
 [snuffleupagus][0.0.0.0][request_logging][error] Unable to create the folder '/root/NON_EXISTENT/FOLDER/PLEASE/'.
 [snuffleupagus][0.0.0.0][request_logging][error] Unable to open /root/NON_EXISTENT/FOLDER/PLEASE/sp_dump_%a_0.0.0.0.dump
-2

--- a/src/tests/inexistent_conf_file_list.phpt
+++ b/src/tests/inexistent_conf_file_list.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Non-existent configuration file in a list
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/../../config/default.ini,{PWD}/non_existent_configuration_file
+--FILE--
+<?php ?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][config][error] Could not open configuration file%a/non_existent_configuration_file : No such file or directory

--- a/src/tests/multi_config.phpt
+++ b/src/tests/multi_config.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Multiple configuration files
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_multi2.ini,{PWD}/config/config_multi1.ini
+--FILE--
+<?php
+function foo() {
+echo "1\n";
+}
+function bla() {
+echo "2\n";
+}
+foo();
+bla();
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'foo' in %s/src/tests/multi_config.php:%d has been disabled.
+1
+[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'bla' in %s/src/tests/multi_config.php:%d has been disabled.
+2
+

--- a/src/tests/upload_validation_invalid.phpt
+++ b/src/tests/upload_validation_invalid.phpt
@@ -14,4 +14,4 @@ echo 1;
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][upload_validation][error] Could not call './tests/data/upload_invalid.sh' : Exec format error
-[snuffleupagus][0.0.0.0][upload_valiation][drop] The upload of test.php on ? was rejected.
+[snuffleupagus][0.0.0.0][upload_validation][drop] The upload of test.php on ? was rejected.

--- a/src/tests/upload_validation_ko_simulation.phpt
+++ b/src/tests/upload_validation_ko_simulation.phpt
@@ -1,8 +1,8 @@
 --TEST--
-Upload a file, validation ko, no simulation
+Upload a file, validation ko, simulation
 --INI--
 file_uploads=1
-sp.configuration_file={PWD}/config/upload_validation_ko.ini
+sp.configuration_file={PWD}/config/upload_validation_ko_simulation.ini
 output_buffering=off
 --POST_RAW--
 Content-Type: multipart/form-data; boundary=blabla
@@ -10,5 +10,6 @@ Content-Type: multipart/form-data; boundary=blabla
 Content-Disposition: form-data; name="test"; filename="test.php"
 --blabla--
 --FILE--
+<?php echo 1337; ?>
 --EXPECTF--
-[snuffleupagus][0.0.0.0][upload_validation][drop] The upload of test.php on ? was rejected.
+1337


### PR DESCRIPTION
 make `.drop()` actually do a `zend_bailout()` to stop execution and avoid any second-order vulnerabilities
