### PR TITLE
Remove sp_disabled_function.drop

### DIFF
--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -94,7 +94,6 @@ typedef struct {
   sp_node_t *var_array_keys;
 
   bool allow;
-  bool drop;
 
   char *var;
 

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -143,7 +143,7 @@ int parse_cookie_encryption(char *line) {
 
 int parse_disabled_functions(char *line) {
   int ret = 0;
-  bool enable = true, disable = false;
+  bool enable = true, disable = false, allow = false, drop = false;
   char *pos = NULL;
   char *line_number = NULL;
   sp_disabled_function *df = pecalloc(sizeof(*df), 1, 1);
@@ -159,8 +159,8 @@ int parse_disabled_functions(char *line) {
       {parse_str, SP_TOKEN_FUNCTION, &(df->function)},
       {parse_regexp, SP_TOKEN_FUNCTION_REGEXP, &(df->r_function)},
       {parse_str, SP_TOKEN_DUMP, &(df->dump)},
-      {parse_empty, SP_TOKEN_ALLOW, &(df->allow)},
-      {parse_empty, SP_TOKEN_DROP, &(df->drop)},
+      {parse_empty, SP_TOKEN_ALLOW, &(allow)},
+      {parse_empty, SP_TOKEN_DROP, &(drop)},
       {parse_str, SP_TOKEN_HASH, &(df->hash)},
       {parse_str, SP_TOKEN_PARAM, &(df->param)},
       {parse_regexp, SP_TOKEN_VALUE_REGEXP, &(df->value_r)},
@@ -224,10 +224,10 @@ int parse_disabled_functions(char *line) {
                " must take a function name on line %zu.",
                line, sp_line_no);
     return -1;
-  } else if (!(df->allow ^ df->drop)) {
+  } else if (!(allow ^ drop)) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s': The "
-               "rule must either be a `drop` or and `allow` one on line %zu.",
+               "rule must either be a `drop` or `allow` one on line %zu.",
                line, sp_line_no);
     return -1;
   }
@@ -253,6 +253,8 @@ int parse_disabled_functions(char *line) {
       return -1;
     }
   }
+
+  df->allow = allow;
 
   if (df->function) {
     df->functions_list = parse_functions_list(df->function);

--- a/src/tests/broken_conf_mutually_exclusive7.phpt
+++ b/src/tests/broken_conf_mutually_exclusive7.phpt
@@ -6,4 +6,4 @@ Broken configuration
 sp.configuration_file={PWD}/config/broken_conf_mutually_exclusive7.ini
 --FILE--
 --EXPECT--
-[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").ret("0").drop().allow();': The rule must either be a `drop` or and `allow` one on line 1.
+[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: 'sp.disabled_functions.function("system").ret("0").drop().allow();': The rule must either be a `drop` or `allow` one on line 1.


### PR DESCRIPTION
Merging `allow` and `drop` in the `sp_disabled_function` structure. As suggested in [this](https://github.com/nbs-system/snuffleupagus/issues/65) issue.