### PR TITLE
Dump environnement variables

### DIFF
--- a/src/tests/config/config_dump_segfault1.ini
+++ b/src/tests/config/config_dump_segfault1.ini
@@ -1,1 +1,1 @@
-sp.disable_function.function("strpos").ret("0").drop().alias("test").dump("/tmp/dump_results/");
+sp.disable_function.function("strpos").ret("0").drop().alias("test").dump("/tmp/dump_result/");

--- a/src/tests/config/dump_request.ini
+++ b/src/tests/config/dump_request.ini
@@ -1,1 +1,1 @@
-sp.disable_function.function("system").drop().dump("/tmp/dump_results/");
+sp.disable_function.function("system").drop().dump("/tmp/dump_result/");

--- a/src/tests/disabled_functions_ret_val_dump.phpt
+++ b/src/tests/disabled_functions_ret_val_dump.phpt
@@ -4,6 +4,8 @@ Disable functions ret val - dump
 <?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
 --INI--
 sp.configuration_file={PWD}/config/disabled_functions_retval_dump.ini
+--ENV--
+DOCUMENT_ROOT=a
 --POST--
 post_a=data_post_a&post_b=data_post_b
 --GET--

--- a/src/tests/dump_request.phpt
+++ b/src/tests/dump_request.phpt
@@ -6,10 +6,10 @@ if (!extension_loaded("snuffleupagus")) {
     print "skip";
 } 
 
-foreach (glob("/tmp/dump_results/*.dump") as $dump) {
+foreach (glob("/tmp/dump_result/sp_dump.*") as $dump) {
     @unlink($dump);
 }
-@rmdir("/tmp/dump_results/");
+@rmdir("/tmp/dump_result/");
 ?>
 --POST--
 post_a=data_post_a&post_b=data_post_b
@@ -21,10 +21,10 @@ cookie_a=data_cookie_a&cookie_b=data_cookie_b
 sp.configuration_file={PWD}/config/dump_request.ini
 --FILE--
 <?php
-@mkdir("/tmp/dump_results/");
+@mkdir("/tmp/dump_result/");
 echo "1\n";
 echo system("echo 1337;");
-$filename = glob('/tmp/dump_results/*.dump')[0];
+$filename = glob('/tmp/dump_result/sp_dump.*')[0];
 $res = file($filename);
 if ($res[1] != "GET:get_a=data_get_a&get_b=data_get_b\n") {
     echo "1\n";

--- a/src/tests/dump_request_too_big.phpt
+++ b/src/tests/dump_request_too_big.phpt
@@ -6,10 +6,10 @@ if (!extension_loaded("snuffleupagus")) {
     print "skip";
 } 
 
-foreach (glob("/tmp/dump_results/*.dump") as $dump) {
+foreach (glob("/tmp/dump_result/sp_dump.*") as $dump) {
     @unlink($dump);
 }
-@rmdir("/tmp/tests/dump_results/");
+@rmdir("/tmp/tests/dump_result/");
 ?>
 --POST--
 post_a=data_post_a&post_b=data_post_b&post_c=c


### PR DESCRIPTION
Apparently, PHP thinks that it's a great idea to type environnement variables,
because why not.