### PR TITLE
fix double decoding

### DIFF
--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -42,7 +42,6 @@ static inline void generate_key(unsigned char *key) {
 int decrypt_cookie(zval *pDest, int num_args, va_list args,
                    zend_hash_key *hash_key) {
   unsigned char key[crypto_secretbox_KEYBYTES] = {0};
-  size_t value_len;
   zend_string *debase64;
   unsigned char *decrypted;
   sp_cookie *cookie = zend_hash_find_ptr(SNUFFLEUPAGUS_G(config).config_cookie->cookies,
@@ -56,13 +55,11 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
 
   generate_key(key);
 
-  value_len = Z_STRLEN_P(pDest);
-
-  if (value_len == 0) {
+  if (Z_STRLEN_P(pDest) == 0) {
     return ZEND_HASH_APPLY_KEEP;
   }
 
-  debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)), value_len);
+  debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)), Z_STRLEN_P(pDest));
 
   if (ZSTR_LEN(debase64) <
       crypto_secretbox_NONCEBYTES + crypto_secretbox_ZEROBYTES) {

--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -53,13 +53,13 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
     return ZEND_HASH_APPLY_KEEP;
   }
 
-  generate_key(key);
-
-  if (Z_STRLEN_P(pDest) == 0) {
+	/* If the cookie has no value, it shouldn't be encrypted. */
+  if (0 == Z_STRLEN_P(pDest)) {
     return ZEND_HASH_APPLY_KEEP;
   }
 
-  debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)), Z_STRLEN_P(pDest));
+  debase64 = php_base64_decode((unsigned char *)(Z_STRVAL_P(pDest)),
+			Z_STRLEN_P(pDest));
 
   if (ZSTR_LEN(debase64) <
       crypto_secretbox_NONCEBYTES + crypto_secretbox_ZEROBYTES) {
@@ -67,6 +67,8 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
         "Buffer underflow tentative detected in cookie encryption handling.");
     return ZEND_HASH_APPLY_REMOVE;
   }
+
+  generate_key(key);
 
   decrypted = pecalloc(ZSTR_LEN(debase64), 1, 0);
 

--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -56,7 +56,7 @@ int decrypt_cookie(zval *pDest, int num_args, va_list args,
 
   generate_key(key);
 
-  value_len = php_url_decode(Z_STRVAL_P(pDest), Z_STRLEN_P(pDest));
+  value_len = Z_STRLEN_P(pDest);
 
   if (value_len == 0) {
     return ZEND_HASH_APPLY_KEEP;


### PR DESCRIPTION
Fixed a double url decoding of base64 value, causing value containing a '+' to be considered as a space.