### PR TITLE
return value setcookie

### DIFF
--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -232,6 +232,7 @@ PHP_FUNCTION(sp_setcookie) {
   call_user_function(CG(function_table), NULL, &func_name, &ret_val, 7, params);
 
   func->handler = PHP_FN(sp_setcookie);
+  RETURN_TRUE;
 }
 
 int hook_cookies() {

--- a/src/tests/samesite_cookies.phpt
+++ b/src/tests/samesite_cookies.phpt
@@ -14,10 +14,18 @@ HTTPS=1
 EOF;
 --FILE--
 <?php
-setcookie("super_cookie", "super_value");
-setcookie("awful_cookie", "awful_value");
-setcookie("not_encrypted", "test_value", 1, "1", "1", false, true);
-setcookie("nice_cookie", "nice_value", 1, "1", "1", true, true);
+if (!setcookie("super_cookie", "super_value")) {
+  echo "setcookie failed.\n";
+}
+if (!setcookie("awful_cookie", "awful_value")) {
+  echo "setcookie failed.\n";
+}
+if (!setcookie("not_encrypted", "test_value", 1, "1", "1", false, true)) {
+  echo "setcookie failed.\n";
+}
+if (!setcookie("nice_cookie", "nice_value", 1, "1", "1", true, true)) {
+  echo "setcookie failed.\n";
+}
 
 $expected = array(
     'Set-Cookie: super_cookie=super_value; path=; samesite=Lax',


### PR DESCRIPTION
We forgot to set a return value to the `setcookie` function, thus always returning `false`. Since very few frameworks/developers are checking the return value, it went unnoticed until we played with Magento, who effectively checks the return value.