### PR TITLE
remove src from path

### DIFF
--- a/src/tests/disabled_functions_register_tick_function.phpt
+++ b/src/tests/disabled_functions_register_tick_function.phpt
@@ -15,4 +15,4 @@ register_tick_function('my_super_function');
 ?>
 --EXPECTF--
 1337
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'my_super_function' in %a/src/tests/disabled_functions_register_tick_function.php:4 has been disabled.
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'my_super_function' in %a/tests/disabled_functions_register_tick_function.php:4 has been disabled.

--- a/src/tests/multi_config.phpt
+++ b/src/tests/multi_config.phpt
@@ -16,8 +16,8 @@ foo();
 bla();
 ?>
 --EXPECTF--
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'foo' in %s/src/tests/multi_config.php:%d has been disabled.
+[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'foo' in %s/tests/multi_config.php:%d has been disabled.
 1
-[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'bla' in %s/src/tests/multi_config.php:%d has been disabled.
+[snuffleupagus][0.0.0.0][disabled_function][simulation] The call to the function 'bla' in %s/tests/multi_config.php:%d has been disabled.
 2
 


### PR DESCRIPTION
Just to make downstream like easier

Context: we are used to duplicate the src tree as NTS and ZTS for dual build (even is ZTS not used for this extension)