### PR TITLE
switch to commonly used version schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ Any maintainer is allowed to merge a PR if all of these conditions are met.
 Maintainers need to do the following to push out a release:
 
 1. Make sure that all pending and mergeable pull requests are in
-2. Update the `snuffleupagus.h` file with the new version number
+2. Update the `snuffleupagus.h` file: drop the -dev suffix and check new version comply with [semantic versioning](https://semver.org/)
 3. Update the changelog page in the documentation
 4. Update the Debian changelog in ./debian/changelog with `dch`
 5. Create a tag for the release:
@@ -136,4 +136,5 @@ Maintainers need to do the following to push out a release:
   ```
 
 6. Create the [release on github](https://github.com/nbs-system/snuffleupagus/releases)
-7. Do the *secret release dance*
+7. Update the `snuffleupagus.h` file: bump the version 3rd digit and add the -dev suffix
+8. Do the *secret release dance*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ clean:  ## clean everything
 	cd src; phpize --clean
 
 release:  ## compile with releases flags
-	sed -i "s/#define PHP_SNUFFLEUPAGUS_COMMIT \"\"/#define PHP_SNUFFLEUPAGUS_COMMIT \"($$(git log --pretty=format:'%h' -n 1))\"/" ./src/php_snuffleupagus.h
 	cd src; phpize
 	cd src; ./configure --enable-snuffleupagus
 	make -C src

--- a/src/php_snuffleupagus.h
+++ b/src/php_snuffleupagus.h
@@ -1,8 +1,7 @@
 #ifndef PHP_SNUFFLEUPAGUS_H
 #define PHP_SNUFFLEUPAGUS_H
 
-#define PHP_SNUFFLEUPAGUS_COMMIT ""
-#define PHP_SNUFFLEUPAGUS_VERSION "0.2 " PHP_SNUFFLEUPAGUS_COMMIT
+#define PHP_SNUFFLEUPAGUS_VERSION "0.2.1-dev"
 #define PHP_SNUFFLEUPAGUS_EXTNAME "snuffleupagus"
 #define PHP_SNUFFLEUPAGUS_AUTHOR "NBS System"
 #define PHP_SNUFFLEUPAGUS_URL "https://github.com/nbs-system/snuffleupagus"


### PR DESCRIPTION
See discussion on #135 

Notice: I also bump version to **0.2.1-dev**, which mean this is a _dev_ version and:
- version needs to be bump to **0.2.1** (or 0.3.0) before release
- version needs to be bump to **0.2.2-dev** after release


