### PR TITLE
Fix a segfault in `get_local_var`

### DIFF
--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -27,6 +27,11 @@ static zval *get_local_var(zend_execute_data *ed, const char *var_name) {
     EG(current_execute_data) = current;
     zend_array *symtable = zend_rebuild_symbol_table();
 
+    if (symtable == NULL) {
+      EG(current_execute_data) = orig_execute_data;
+      return NULL;
+    }
+    
     ZEND_HASH_FOREACH_STR_KEY_VAL(symtable, key, value) {
       if (0 == strcmp(var_name, key->val)) {
         if (Z_TYPE_P(value) == IS_INDIRECT) {

--- a/src/sp_var_value.c
+++ b/src/sp_var_value.c
@@ -27,11 +27,11 @@ static zval *get_local_var(zend_execute_data *ed, const char *var_name) {
     EG(current_execute_data) = current;
     zend_array *symtable = zend_rebuild_symbol_table();
 
-    if (symtable == NULL) {
+    if (UNEXPECTED(symtable == NULL)) {
       EG(current_execute_data) = orig_execute_data;
       return NULL;
     }
-    
+
     ZEND_HASH_FOREACH_STR_KEY_VAL(symtable, key, value) {
       if (0 == strcmp(var_name, key->val)) {
         if (Z_TYPE_P(value) == IS_INDIRECT) {

--- a/src/tests/disabled_function_local_var_crash.phpt
+++ b/src/tests/disabled_function_local_var_crash.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Disable functions - match on a local variable
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/disabled_function_local_var.ini
+--FILE--
+<?php 
+function test(){
+    $a = "1337";
+    echo strlen("id") . "\n";
+}
+ob_start(test);
+?>
+--EXPECTF--
+Notice: Use of undefined constant test - assumed 'test' in %a/disabled_function_local_var_crash.php on line %d
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'strlen' in %a/disabled_function_local_var_crash.php:%d has been disabled.

--- a/src/tests/disabled_function_local_var_crash.phpt
+++ b/src/tests/disabled_function_local_var_crash.phpt
@@ -10,8 +10,10 @@ function test(){
 //    $a = "1337";
     echo strlen("id") . "\n";
 }
-ob_start(test);
-echo "lol\n";
+ob_start(test());
+echo "test\n";
 ?>
 --EXPECTF--
-Notice: Use of undefined constant test - assumed 'test' in %a/disabled_function_local_var_crash.php on line %d
+2
+test
+

--- a/src/tests/disabled_function_local_var_crash.phpt
+++ b/src/tests/disabled_function_local_var_crash.phpt
@@ -7,11 +7,11 @@ sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--
 <?php 
 function test(){
-    $a = "1337";
+//    $a = "1337";
     echo strlen("id") . "\n";
 }
 ob_start(test);
+echo "lol\n";
 ?>
 --EXPECTF--
 Notice: Use of undefined constant test - assumed 'test' in %a/disabled_function_local_var_crash.php on line %d
-[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'strlen' in %a/disabled_function_local_var_crash.php:%d has been disabled.

--- a/src/tests/disabled_function_local_var_crash.phpt
+++ b/src/tests/disabled_function_local_var_crash.phpt
@@ -7,7 +7,6 @@ sp.configuration_file={PWD}/config/disabled_function_local_var.ini
 --FILE--
 <?php 
 function test(){
-//    $a = "1337";
     echo strlen("id") . "\n";
 }
 ob_start(test());


### PR DESCRIPTION
If we are not in a function yet, `get_local_var` will trigger a crash, because `symtable` will be NULL and then `ZEND_HASH_FOREACH_STR_KEY_VAL` will NULL-deref.
