### PR TITLE
 add example rule from the rips calendar

### DIFF
--- a/config/rips.rules
+++ b/config/rips.rules
@@ -1,0 +1,1 @@
+sp.disable_function.function("define").filename_r("/static_pages/index.php").var("$_SERVER[PHP_SELF]").value_r("\"").drop();

--- a/src/tests/rips_configuration.phpt
+++ b/src/tests/rips_configuration.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Shipped configuration (rips)
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/../../config/rips.rules
+--FILE--
+<?php 
+system("echo 0");
+?>
+--EXPECTF--
+0


### PR DESCRIPTION

add example rule from the rips calendar ￼…
As stated in the [blog post]( https://blog.ripstech.com/2016/abantecart-multiple-sql-injections/ ) from the fine people of RIPS Tech, in the file ``/static_pages/index.php``, the variable ``$_SERVER["PHP_SELF"]`` contains the end of a user-controlled path, later reflected in the web page via `<a href="<?php echo HTTP_ABANTECART; ?>">Go to main page</a>`.

This can be used as an XSS vector, and can be prevented by forbidding the usage of the  `"` character.

Here screenshots which proof the successful of the rule:

![poc_xss](https://user-images.githubusercontent.com/26606307/35865562-237aa414-0b55-11e8-9f5d-1bc37ddb8d86.png)

successful drop in the define function:
![xss_log](https://user-images.githubusercontent.com/26606307/35155690-c5120df6-fd2e-11e7-9a27-1af46222dda8.png)

successful drop in the dirname function
![xss_log3](https://user-images.githubusercontent.com/26606307/35155758-0a811eea-fd2f-11e7-896a-e75560a016c0.png)