### PR TITLE
php-nightly is now allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,20 @@ matrix:
   - env: TARGET="clang php7.1" CC="clang"
     php: '7.1'
   - env: TARGET="clang php7.2" CC="clang"
+    before_install: pip install --user cpp-coveralls
     php: '7.2'
   - env: TARGET="gcc php nightly" CC="gcc"
-    before_install: pip install --user cpp-coveralls
+    php: nightly
+  - env: TARGET="clang php nightly" CC="clang"
     php: nightly
   allow_failures:
+  - env: TARGET="gcc php nightly" CC="gcc"
+    php: nightly
   - env: TARGET="clang php nightly" CC="clang"  # https://bugs.llvm.org/show_bug.cgi?id=9295
     php: nightly
 
 script:
+  - pecl install vld-beta
   - cd src
   - phpize
   - ./configure --enable-snuffleupagus --enable-coverage

--- a/scripts/upload_validation.py
+++ b/scripts/upload_validation.py
@@ -14,6 +14,7 @@ def check(filename):
             "-d", "vld.format=1",
             "-d", "vld.col_sep=@",
             "-d", "log_errors=0",
+            "-d", "error_log=/dev/null",
             filename],
             stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:

--- a/src/tests/upload_validation_real.phpt
+++ b/src/tests/upload_validation_real.phpt
@@ -2,7 +2,7 @@
 Upload a file, validation ok, with our real script, using vld
 --SKIPIF--
 <?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
-<?php if (strpos(system("php -d extension=vld.so -m"), "vld") === FALSE) print "skip"; ?>
+<?php if (strpos(system("php -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null"), "vld") === FALSE) print "skip"; ?>
 --INI--
 file_uploads=1
 sp.configuration_file={PWD}/config/upload_validation_real.ini


### PR DESCRIPTION
PHP is breaking too many things on nightly, we'll only support releases from
now on.

This should also make our `vld`-based file-upload checker more resilient: no more random warnings on `stderr`.