### PR TITLE
Make the rules processing a bit stricter

### DIFF
--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -282,7 +282,8 @@ int parse_disabled_functions(char *line) {
                "`key` and `value` are mutually exclusive on line %zu.",
                line, sp_line_no);
     return -1;
-  } else if ((df->r_ret || df->ret) && (df->r_param || param)) {
+  } else if ((df->r_ret || df->ret) &&
+             (df->r_param || param || df->param_type)) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s':"
                "`ret` and `param` are mutually exclusive on line %zu.",
@@ -304,6 +305,15 @@ int parse_disabled_functions(char *line) {
     sp_log_err("config",
                "Invalid configuration line: 'sp.disabled_functions%s': The "
                "rule must either be a `drop` or `allow` one on line %zu.",
+               line, sp_line_no);
+    return -1;
+  } else if (!(df->value || df->value_r || df->key || df->r_key ||
+               df->param_type) &&
+             (df->r_param || param)) {
+    sp_log_err("config",
+               "Invalid configuration line: 'sp.disabled_functions%s':"
+               "you can't filter on a param without giving a value or a key, "
+               "on line %zu.",
                line, sp_line_no);
     return -1;
   }


### PR DESCRIPTION
The current behaviour is to drop on presence. I think that we want to mandate a key or value.

This is currently allowed:

```python
sp.disabled_functions.function("foo").param("arr[test]").alias("3").drop();
```

With this PR:

```python
[snuffleupagus][0.0.0.0][config][error] Invalid configuration line: sp.disabled_functions.function("foo").param("arr[test]").alias("3").drop();':you can't filter on a param without giving a value or a key, on line 3.
```

Thoughs @buixor @blotus ?