### PR TITLE
Use shell_exec() instead of system() to check for vld's presence

### DIFF
--- a/src/tests/upload_validation_real.phpt
+++ b/src/tests/upload_validation_real.phpt
@@ -1,8 +1,10 @@
 --TEST--
 Upload a file, validation ok, with our real script, using vld
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
-<?php if (strpos(system("php -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null"), "vld") === FALSE) print "skip"; ?>
+<?php 
+if (!extension_loaded("snuffleupagus")) print "skip";
+if (strpos(shell_exec("php -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null"), "vld") === FALSE) print "skip";
+?>
 --INI--
 file_uploads=1
 sp.configuration_file={PWD}/config/upload_validation_real.ini

--- a/src/tests/upload_validation_real.phpt
+++ b/src/tests/upload_validation_real.phpt
@@ -1,9 +1,10 @@
 --TEST--
 Upload a file, validation ok, with our real script, using vld
 --SKIPIF--
-<?php 
+<?php
 if (!extension_loaded("snuffleupagus")) print "skip";
-if (strpos(shell_exec("php -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null"), "vld") === FALSE) print "skip";
+$res = exec("php -d error_log=/dev/null -d extension=vld.so -m 2>/dev/null", $output);
+if (in_array("vld", $output) === FALSE) print "skip";
 ?>
 --INI--
 file_uploads=1


### PR DESCRIPTION
The issue was that system prints all the output from the command whereas
shell_exec doesn't