### PR TITLE
Add test for callback function as parameter

### DIFF
--- a/src/tests/config/config_disabled_functions_callback_called_file_r.ini
+++ b/src/tests/config/config_disabled_functions_callback_called_file_r.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("test_callback").filename_r("file_r\\.php$").drop();

--- a/src/tests/disabled_functions_callback_called_file_r.phpt
+++ b/src/tests/disabled_functions_callback_called_file_r.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Disable functions by matching on the filename_r where the callback function is called, and not defined
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_disabled_functions_callback_called_file_r.ini
+--FILE--
+<?php
+$dir = __DIR__;
+
+@unlink("$dir/myfunc_callback.php");
+
+$mycode = <<< 'EOD'
+<?php
+
+function test_callback() {
+	return "Test_callback";
+}
+
+function test(callable $toto) {
+	return $toto();
+}
+?>
+EOD;
+
+file_put_contents("$dir/myfunc_callback.php", $mycode);
+
+include "$dir/myfunc_callback.php";
+
+echo test('test_callback');
+
+?>
+--EXPECTF--
+[snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'test_callback' in %a/disabled_functions_callback__called_file_r.php:%d has been disabled.

--- a/src/tests/disabled_functions_callback_called_file_r.phpt
+++ b/src/tests/disabled_functions_callback_called_file_r.phpt
@@ -32,3 +32,9 @@ echo test('test_callback');
 ?>
 --EXPECTF--
 [snuffleupagus][0.0.0.0][disabled_function][drop] The call to the function 'test_callback' in %a/disabled_functions_callback__called_file_r.php:%d has been disabled.
+--XFAIL--
+--CLEAN--
+<?php
+$dir = __DIR__;
+@unlink("$dir/myfunc_callback.php");
+?>


### PR DESCRIPTION
Since matching on the filename where the function is called and not where it's defined for a callback function as parameter doesn't work, here is a test to prove it.