### PR TITLE
Add a whitelist for php's wrappers

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -109,8 +109,9 @@ It can either be ``enabled`` or ``disabled``.
 Prevent sloppy comparison
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-sloppy_comparison, disabled by default, will prevent php `type
-juggling <https://secure.php.net/manual/en/language.types.type-juggling.php>`_ (``==``) , preventing any bypass of a comparison.
+:ref:`Sloppy comparison prevention <sloppy-comparisons-feature>`, disabled by default, will prevent php `type
+juggling <https://secure.php.net/manual/en/language.types.type-juggling.php>`_ (``==``):
+two values with different types will always be different.
 
 It can either be ``enabled`` or ``disabled``.
 

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -327,10 +327,9 @@ annotated types and native functions, so it doesn't cover every instances of
 during comparisons. Since comparison between different types in PHP is
 `notoriously <https://secure.php.net/manual/en/types.comparisons.php>`__
 difficult to get right, Snuffleupagus offers a way to **always** use the
-``identical`` operator instead of the ``equal`` one (see the `operator section
-<https://secure.php.net/manual/en/language.operators.comparison.php>` for PHP's documentation
-for more details), so that values with different types will always be treated
-as being different.
+``identical`` operator instead of the ``equal`` one (see the `operator section <https://secure.php.net/manual/en/language.operators.comparison.php>`__
+for PHP's documentation for more details), so that values with different types
+will always be treated as being different.
 
 .. _readonly-exec-feature:
 

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -316,6 +316,22 @@ This feature is largely inspired from the
 `autostrict <https://github.com/krakjoe/autostrict>`_ module from `krakjoe <http://krakjoe.ninja>`__.
 
 
+.. _sloppy-comparisons-feature:
+
+Preventing sloppy comparisons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The aforementioned :ref:`strict mode <global-strict-feature>` only works with
+annotated types and native functions, so it doesn't cover every instances of
+`type juggling <https://secure.php.net/manual/en/language.types.type-juggling.php>`
+during comparisons. Since comparison between different types in PHP is
+`notoriously <https://secure.php.net/manual/en/types.comparisons.php>`__
+difficult to get right, Snuffleupagus offers a way to **always** use the
+``identical`` operator instead of the ``equal`` one (see the `operator section
+<https://secure.php.net/manual/en/language.operators.comparison.php>` for PHP's documentation
+for more details), so that values with different types will always be treated
+as being different.
+
 .. _readonly-exec-feature:
 
 Preventing execution of writable PHP files

--- a/src/config.m4
+++ b/src/config.m4
@@ -6,7 +6,7 @@ sources="$sources sp_unserialize.c sp_utils.c sp_disable_xxe.c sp_list.c"
 sources="$sources sp_disabled_functions.c sp_execute.c sp_upload_validation.c"
 sources="$sources sp_cookie_encryption.c sp_network_utils.c tweetnacl.c"
 sources="$sources sp_config_keywords.c sp_var_parser.c sp_var_value.c sp_tree.c"
-sources="$sources sp_pcre_compat.c sp_crypt.c sp_session.c sp_sloppy.c"
+sources="$sources sp_pcre_compat.c sp_crypt.c sp_session.c sp_sloppy.c sp_wrapper.c"
 
 PHP_ARG_ENABLE(snuffleupagus, whether to enable snuffleupagus support,
 [  --enable-snuffleupagus           Enable snuffleupagus support])

--- a/src/php_snuffleupagus.h
+++ b/src/php_snuffleupagus.h
@@ -44,6 +44,7 @@
 #include "sp_crypt.h"
 #include "sp_session.h"
 #include "sp_sloppy.h"
+#include "sp_wrapper.h"
 
 extern zend_module_entry snuffleupagus_module_entry;
 #define phpext_snuffleupagus_ptr &snuffleupagus_module_entry

--- a/src/snuffleupagus.c
+++ b/src/snuffleupagus.c
@@ -255,6 +255,9 @@ static PHP_INI_MH(OnUpdateConfiguration) {
   if (SNUFFLEUPAGUS_G(config).config_disable_xxe->enable == 0) {
     hook_libxml_disable_entity_loader();
   }
+  if (SNUFFLEUPAGUS_G(config).config_wrapper->enabled) {
+    hook_stream_wrappers();
+  }
   hook_disabled_functions();
   hook_execute();
 

--- a/src/snuffleupagus.c
+++ b/src/snuffleupagus.c
@@ -181,6 +181,7 @@ PHP_RINIT_FUNCTION(snuffleupagus) {
   ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 
+  // We need to disable wrappers loaded by extensions loaded after SNUFFLEUPAGUS.
   if (SNUFFLEUPAGUS_G(config).config_wrapper->enabled &&
       zend_hash_num_elements(php_stream_get_url_stream_wrappers_hash()) !=
       SNUFFLEUPAGUS_G(config).config_wrapper->num_wrapper) {

--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -78,6 +78,12 @@ typedef struct {
 } sp_cookie;
 
 typedef struct {
+  sp_list_node *whitelist;
+  bool enabled;
+  size_t num_wrapper;
+} sp_config_wrapper;
+
+typedef struct {
   bool encrypt;
   bool simulation;
 } sp_config_session;
@@ -166,6 +172,7 @@ typedef struct {
   sp_config_global_strict *config_global_strict;
   sp_config_disable_xxe *config_disable_xxe;
   sp_config_eval *config_eval;
+  sp_config_wrapper *config_wrapper;
   sp_config_session *config_session;
   bool hook_execute;
 
@@ -204,6 +211,7 @@ typedef struct {
 #define SP_TOKEN_EVAL_BLACKLIST ".eval_blacklist"
 #define SP_TOKEN_EVAL_WHITELIST ".eval_whitelist"
 #define SP_TOKEN_SLOPPY_COMPARISON ".sloppy_comparison"
+#define SP_TOKEN_ALLOW_WRAPPERS ".allow_wrappers"
 
 // common tokens
 #define SP_TOKEN_ENABLE ".enable("
@@ -256,8 +264,7 @@ typedef struct {
 // upload_validator
 #define SP_TOKEN_UPLOAD_SCRIPT ".script("
 
-// eval blacklist
-#define SP_TOKEN_EVAL_LIST ".list("
+#define SP_TOKEN_LIST ".list("
 
 int sp_parse_config(const char *);
 int parse_array(sp_disabled_function *);
@@ -267,6 +274,7 @@ int parse_regexp(char *restrict, char *restrict, void *);
 int parse_empty(char *restrict, char *restrict, void *);
 int parse_cidr(char *restrict, char *restrict, void *);
 int parse_php_type(char *restrict, char *restrict, void *);
+int parse_list(char *restrict, char *restrict, void *);
 
 // cleanup
 void sp_disabled_function_list_free(sp_list_node *);

--- a/src/sp_config.h
+++ b/src/sp_config.h
@@ -80,7 +80,7 @@ typedef struct {
 typedef struct {
   sp_list_node *whitelist;
   bool enabled;
-  size_t num_wrapper;
+  size_t num_wrapper;  // Used to verify if wrappers were added.
 } sp_config_wrapper;
 
 typedef struct {
@@ -211,7 +211,7 @@ typedef struct {
 #define SP_TOKEN_EVAL_BLACKLIST ".eval_blacklist"
 #define SP_TOKEN_EVAL_WHITELIST ".eval_whitelist"
 #define SP_TOKEN_SLOPPY_COMPARISON ".sloppy_comparison"
-#define SP_TOKEN_ALLOW_WRAPPERS ".allow_wrappers"
+#define SP_TOKEN_ALLOW_WRAPPERS ".wrappers_whitelist"
 
 // common tokens
 #define SP_TOKEN_ENABLE ".enable("

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -166,12 +166,11 @@ int parse_global(char *line) {
 }
 
 static int parse_eval_filter_conf(char *line, sp_list_node **list) {
-  char *token, *tmp;
   zend_string *rest = NULL;
   sp_config_eval *eval = SNUFFLEUPAGUS_G(config).config_eval;
 
   sp_config_functions sp_config_funcs[] = {
-      {parse_str, SP_TOKEN_EVAL_LIST, &rest},
+      {parse_list, SP_TOKEN_LIST, list},
       {parse_empty, SP_TOKEN_SIMULATION,
        &(SNUFFLEUPAGUS_G(config).config_eval->simulation)},
       {parse_str, SP_TOKEN_DUMP, &(SNUFFLEUPAGUS_G(config).config_eval->dump)},
@@ -184,12 +183,21 @@ static int parse_eval_filter_conf(char *line, sp_list_node **list) {
     return ret;
   }
 
-  tmp = ZSTR_VAL(rest);
-  while ((token = strtok_r(tmp, ",", &tmp))) {
-    *list = sp_list_insert(*list, zend_string_init(token, strlen(token), 1));
-  }
   if (rest != NULL) {
     pefree(rest, 1);
+  }
+  return SUCCESS;
+}
+
+int parse_wrapper_whitelist(char *line) {
+  SNUFFLEUPAGUS_G(config).config_wrapper->enabled = true;
+  sp_config_functions sp_config_funcs[] = {
+      {parse_list, SP_TOKEN_LIST,
+       &SNUFFLEUPAGUS_G(config).config_wrapper->whitelist},
+      {0}};
+  int ret = parse_keywords(sp_config_funcs, line);
+  if (0 != ret) {
+    return ret;
   }
   return SUCCESS;
 }

--- a/src/sp_config_keywords.h
+++ b/src/sp_config_keywords.h
@@ -16,5 +16,6 @@ int parse_eval_blacklist(char *line);
 int parse_eval_whitelist(char *line);
 int parse_session(char *line);
 int parse_sloppy_comparison(char *line);
+int parse_wrapper_whitelist(char *line);
 
 #endif  // __SP_CONFIG_KEYWORDS_H

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -4,10 +4,10 @@
 ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
 
 static bool wrapper_is_whitelisted(const zend_string *zs) {
-  sp_list_node *list = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
+  const sp_list_node *list = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
 
   while (list) {
-    if (zend_string_equals_ci(zs, (zend_string*)list->data)) {
+    if (zend_string_equals_ci(zs, (const zend_string*)list->data)) {
       return true;
     }
     list = list->next;

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -3,29 +3,64 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
 
+static bool wrapper_is_whitelisted(const zend_string *zs) {
+  sp_list_node *list = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
+
+  while (list) {
+    if (zend_string_equals_ci(zs, (zend_string*)list->data)) {
+      return true;
+    }
+    list = list->next;
+  }
+  return false;
+}
+
 void sp_disable_wrapper() {
   HashTable *orig = php_stream_get_url_stream_wrappers_hash();
-  HashTable *full = pemalloc(sizeof(*full), 1);
+  HashTable *orig_complete = pemalloc(sizeof(*orig_complete), 1);
   zval *zv;
   zend_string *zs;
 
-  zend_hash_init(full, zend_hash_num_elements(orig), NULL, NULL, 1);
-  zend_hash_copy(full, orig, NULL);
+  // Copy the original hashtable into a temporary one, as I'm not sure about
+  // the behaviour of ZEND_HASH_FOREACH when element are removed from the
+  // hashtable used in the loop.
+  zend_hash_init(orig_complete, zend_hash_num_elements(orig), NULL, NULL, 1);
+  zend_hash_copy(orig_complete, orig, NULL);
   zend_hash_clean(orig);
 
-  ZEND_HASH_FOREACH_STR_KEY_VAL(full, zs, zv) {
-    sp_list_node *tmp = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
-    while (tmp) {
-      if (zend_string_equals_ci(zs, (zend_string*)tmp->data)) {
-        zend_hash_add(orig, zs, zv);
-        break;
-      }
-      tmp = tmp->next;
+  ZEND_HASH_FOREACH_STR_KEY_VAL(orig_complete, zs, zv) {
+    if (wrapper_is_whitelisted(zs)) {
+      zend_hash_add(orig, zs, zv);
     }
   }
-
   ZEND_HASH_FOREACH_END();
-  zend_hash_destroy(full);
-  pefree(full, 1);
+
+  zend_hash_destroy(orig_complete);
+  pefree(orig_complete, 1);
   SNUFFLEUPAGUS_G(config).config_wrapper->num_wrapper = zend_hash_num_elements(orig);
+}
+
+PHP_FUNCTION(sp_stream_wrapper_register) {
+  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zend_string *protocol_name = NULL;
+
+  ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 2, EX_NUM_ARGS());
+  Z_PARAM_STR(protocol_name);
+  ZEND_PARSE_PARAMETERS_END_EX((void)0);
+
+  if (wrapper_is_whitelisted(protocol_name)) {
+    orig_handler = zend_hash_str_find_ptr(
+        SNUFFLEUPAGUS_G(sp_internal_functions_hook),
+        "stream_wrapper_register", sizeof("stream_wrapper_register") - 1);
+    orig_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  }
+}
+
+int hook_stream_wrappers() {
+  TSRMLS_FETCH();
+
+  HOOK_FUNCTION("stream_wrapper_register", sp_internal_functions_hook,
+                PHP_FN(sp_stream_wrapper_register));
+
+  return SUCCESS;
 }

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -6,6 +6,10 @@ ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
 static bool wrapper_is_whitelisted(const zend_string *zs) {
   const sp_list_node *list = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
 
+  if (!zs) {
+    return false;
+  }
+
   while (list) {
     if (zend_string_equals_ci(zs, (const zend_string*)list->data)) {
       return true;

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -1,0 +1,31 @@
+#include "php_snuffleupagus.h"
+#include "sp_config.h"
+
+ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
+
+void sp_disable_wrapper() {
+  HashTable *orig = php_stream_get_url_stream_wrappers_hash();
+  HashTable *full = pemalloc(sizeof(*full), 1);
+  zval *zv;
+  zend_string *zs;
+
+  zend_hash_init(full, zend_hash_num_elements(orig), NULL, NULL, 1);
+  zend_hash_copy(full, orig, NULL);
+  zend_hash_clean(orig);
+
+  ZEND_HASH_FOREACH_STR_KEY_VAL(full, zs, zv) {
+    sp_list_node *tmp = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
+    while (tmp) {
+      if (zend_string_equals_ci(zs, (zend_string*)tmp->data)) {
+        zend_hash_add(orig, zs, zv);
+        break;
+      }
+      tmp = tmp->next;
+    }
+  }
+
+  ZEND_HASH_FOREACH_END();
+  zend_hash_destroy(full);
+  pefree(full, 1);
+  SNUFFLEUPAGUS_G(config).config_wrapper->num_wrapper = zend_hash_num_elements(orig);
+}

--- a/src/sp_wrapper.h
+++ b/src/sp_wrapper.h
@@ -3,5 +3,6 @@
 #include "php_snuffleupagus.h"
 
 void sp_disable_wrapper();
+int hook_stream_wrappers();
 
 #endif

--- a/src/sp_wrapper.h
+++ b/src/sp_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SP_WRAPPER_H
+#define SP_WRAPPER_H
+#include "php_snuffleupagus.h"
+
+void sp_disable_wrapper();
+
+#endif

--- a/src/tests/config/config_stream_wrapper.ini
+++ b/src/tests/config/config_stream_wrapper.ini
@@ -1,1 +1,1 @@
-sp.allow_wrappers.list("https,FTP,does_not_exist");
+sp.wrappers_whitelist.list("https,FTP,does_not_exist");

--- a/src/tests/config/config_stream_wrapper.ini
+++ b/src/tests/config/config_stream_wrapper.ini
@@ -1,0 +1,1 @@
+sp.allow_wrappers.list("https,FTP,does_not_exist");

--- a/src/tests/config/config_stream_wrapper_register.ini
+++ b/src/tests/config/config_stream_wrapper_register.ini
@@ -1,0 +1,1 @@
+sp.wrappers_whitelist.list("php,lelel");

--- a/src/tests/stream_wrapper.phpt
+++ b/src/tests/stream_wrapper.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Stream wrapper
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_stream_wrapper.ini
+--FILE--
+<?php 
+file_get_contents('http://qweqwezxc');
+file_get_contents('https://qweqwezxc');
+file_get_contents('ftp://qweqwezxc');
+file_get_contents('lelel://qweqwezxc');
+?>
+--EXPECTF--
+Warning: Unknown: Unable to find the wrapper "php" - did you forget to enable it when you configured PHP? in Unknown on line 0
+
+Warning: Unknown: Unable to find the wrapper "php" - did you forget to enable it when you configured PHP? in Unknown on line 0
+
+Warning: Unknown: Unable to find the wrapper "php" - did you forget to enable it when you configured PHP? in Unknown on line 0
+
+Warning: file_get_contents(): Unable to find the wrapper "http" - did you forget to enable it when you configured PHP? in %a/tests/stream_wrapper.php on line %d
+
+Warning: file_get_contents(): php_network_getaddresses: getaddrinfo failed: Name or service not known in %a/tests/stream_wrapper.php on line %d
+
+Warning: file_get_contents(https://qweqwezxc): failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known in %a/tests/stream_wrapper.php on line %d
+
+Warning: file_get_contents(ftp://qweqwezxc): failed to open stream: operation failed in %a/tests/stream_wrapper.php on line %d
+
+Warning: file_get_contents(): Unable to find the wrapper "lelel" - did you forget to enable it when you configured PHP? in %a/tests/stream_wrapper.php on line %d
+
+Warning: file_get_contents(lelel://qweqwezxc): failed to open stream: No such file or directory in %a/tests/stream_wrapper.php on line %d

--- a/src/tests/stream_wrapper_register.phpt
+++ b/src/tests/stream_wrapper_register.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Stream wrapper
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_stream_wrapper_register.ini
+--FILE--
+<?php 
+class qwe {
+  function stream_open($fname) {
+    return $fname;
+  }
+}
+
+stream_wrapper_register("lelel", "qwe");
+stream_wrapper_register("lolol", "qwe");
+fopen("lelel://asdasd", "r");
+fopen("lolol://asdasd", "r");
+?>
+--EXPECTF--
+Warning: fopen(): Unable to find the wrapper "lolol" - did you forget to enable it when you configured PHP? in %a/tests/stream_wrapper_register.php on line %d
+
+Warning: fopen(): file:// wrapper is disabled in the server configuration in %a/tests/stream_wrapper_register.php on line %d
+
+Warning: fopen(lolol://asdasd): failed to open stream: no suitable wrapper could be found in %a/tests/stream_wrapper_register.php on line %d

--- a/src/tests/stream_wrapper_restore.phpt
+++ b/src/tests/stream_wrapper_restore.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Stream wrapper
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_stream_wrapper_register.ini
+--FILE--
+<?php 
+stream_wrapper_restore("file");
+fopen("file://asdasd", "r");
+?>
+--EXPECTF--
+Notice: stream_wrapper_restore(): file:// was never changed, nothing to restore in %a/tests/stream_wrapper_restore.php on line %d
+
+Warning: fopen(): Unable to find the wrapper "file" - did you forget to enable it when you configured PHP? in %a/tests/stream_wrapper_restore.php on line %d
+
+Warning: fopen(file://asdasd): failed to open stream: No such file or directory in %a/tests/stream_wrapper_restore.php on line %d


### PR DESCRIPTION
As suggested in https://github.com/nbs-system/snuffleupagus/issues/209

- [x] hook [stream_wrapper_register](http://php.net/manual/fr/function.stream-wrapper-register.php)
- [x] add some doc
  - [x] in the *feature* section
  - [x] in the *configuration* section
- [x] add test for `stream_wrapper_register`