### PR TITLE
use php_setcookie function (PHP public API)

### DIFF
--- a/src/tests/samesite_cookies.phpt
+++ b/src/tests/samesite_cookies.phpt
@@ -3,7 +3,6 @@ Cookie samesite
 --SKIPIF--
 <?php
 if (!extension_loaded("snuffleupagus")) die("skip");
-if (PHP_VERSION_ID >= 70300) die("skip BROKEN with 7.3");
 ?>
 --INI--
 sp.configuration_file={PWD}/config/config_samesite_cookies.ini


### PR DESCRIPTION
Simplify a lot the function (using PHP public API instead of `call_user_function` hack)

This make the samesite test passes on 7.1, 7.2 and 7.3

I think it can be a nice idea to handle this to allow user to have same configuration on various PHP versions.

