### PR TITLE
Use case insensitive comparison

### DIFF
--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -484,7 +484,7 @@ int parse_disabled_functions(char *line) {
     return ret;
   }
 
-  if (df->function && zend_string_equals_literal(df->function, "print")) {
+  if (df->function && zend_string_equals_literal_ci(df->function, "print")) {
     zend_string_release(df->function);
     df->function = zend_string_init("echo", strlen("echo"), 1);
   }

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -208,11 +208,11 @@ static zend_execute_data* is_file_matching(
 
   zend_execute_data* ex = execute_data;
   if (config_node->filename) {
-    if (zend_string_equals(current_filename, config_node->filename)) {
+    if (zend_string_equals_ci(current_filename, config_node->filename)) {
       return ex;
     }
     ITERATE(ex);
-    if (zend_string_equals(ex->func->op_array.filename,
+    if (zend_string_equals_ci(ex->func->op_array.filename,
                                    config_node->filename)) {
       return ex;
     }
@@ -233,11 +233,11 @@ static zend_execute_data* is_file_matching(
 static bool check_is_builtin_name(
     sp_disabled_function const* const config_node) {
   if (config_node->function) {
-    return (zend_string_equals_literal(config_node->function, "include") ||
-            zend_string_equals_literal(config_node->function, "include_once") ||
-            zend_string_equals_literal(config_node->function, "require") ||
-            zend_string_equals_literal(config_node->function, "require_once") ||
-            zend_string_equals_literal(config_node->function, "echo"));
+    return (zend_string_equals_literal_ci(config_node->function, "include") ||
+            zend_string_equals_literal_ci(config_node->function, "include_once") ||
+            zend_string_equals_literal_ci(config_node->function, "require") ||
+            zend_string_equals_literal_ci(config_node->function, "require_once") ||
+            zend_string_equals_literal_ci(config_node->function, "echo"));
   }
   if (config_node->r_function) {
     return (sp_is_regexp_matching(config_node->r_function, "include") ||

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -19,14 +19,6 @@ static inline void _sp_log_err(const char* fmt, ...) {
   php_log_err(msg);
 }
 
-static bool sp_zend_string_equals(const zend_string* s1,
-                                  const zend_string* s2) {
-  // We can't use `zend_string_equals` here because it doesn't work on
-  // `const` zend_string.
-  return ZSTR_LEN(s1) == ZSTR_LEN(s2) &&
-         !memcmp(ZSTR_VAL(s1), ZSTR_VAL(s2), ZSTR_LEN(s1));
-}
-
 void sp_log_msg(char const* feature, char const* level, const char* fmt, ...) {
   char* msg;
   va_list args;
@@ -200,7 +192,7 @@ const zend_string* sp_zval_to_zend_string(zval* zv) {
 bool sp_match_value(const zend_string* value, const zend_string* to_match,
                     const sp_pcre* rx) {
   if (to_match) {
-    return (sp_zend_string_equals(to_match, value));
+    return (zend_string_equals_ci(to_match, value));
   } else if (rx) {
     char* tmp = zend_string_to_char(value);
     bool ret = sp_is_regexp_matching(rx, tmp);
@@ -405,7 +397,7 @@ bool check_is_in_eval_whitelist(const zend_string* const function_name) {
   /* yes, we could use a HashTable instead, but since the list is pretty
    * small, it doesn't maka a difference in practise. */
   while (it && it->data) {
-    if (sp_zend_string_equals(function_name, (const zend_string*)(it->data))) {
+    if (zend_string_equals_ci(function_name, (const zend_string*)(it->data))) {
       /* We've got a match, the function is whiteslited. */
       return true;
     }


### PR DESCRIPTION
`sp_zend_string_equals` is no longer required as `zend_string_equals_ci` can be used with `const`.