### PR TITLE
fix SIGSEGV on user function return value

### DIFF
--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -187,14 +187,16 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
 
     orig_execute_ex(execute_data);
 
-    if (UNEXPECTED(
+    if (EX(return_value) != NULL) {
+      if (UNEXPECTED(
             true ==
             should_drop_on_ret_ht(
-                EX(return_value), function_name,
-                SNUFFLEUPAGUS_G(config)
-                    .config_disabled_functions_reg_ret->disabled_functions,
-                SNUFFLEUPAGUS_G(config).config_disabled_functions_ret))) {
-      sp_terminate();
+              EX(return_value), function_name,
+              SNUFFLEUPAGUS_G(config)
+              .config_disabled_functions_reg_ret->disabled_functions,
+              SNUFFLEUPAGUS_G(config).config_disabled_functions_ret))) {
+        sp_terminate();
+      }
     }
     efree(function_name);
   } else {

--- a/src/tests/config/config_disabled_functions_ret_user.ini
+++ b/src/tests/config/config_disabled_functions_ret_user.ini
@@ -1,0 +1,1 @@
+sp.disable_function.function("qwe").ret("asd").drop();

--- a/src/tests/disabled_functions_ret_user.phpt
+++ b/src/tests/disabled_functions_ret_user.phpt
@@ -10,5 +10,7 @@ function qwe() {
   return "asd";
 }
 qwe();
+echo 1;
 ?>
 --EXPECT--
+1

--- a/src/tests/disabled_functions_ret_user.phpt
+++ b/src/tests/disabled_functions_ret_user.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Check NULL return value for user func
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_disabled_functions_ret_user.ini
+--FILE--
+<?php 
+function qwe() {
+  return "asd";
+}
+qwe();
+?>
+--EXPECT--

--- a/src/tests/disabled_functions_ret_user_used.phpt
+++ b/src/tests/disabled_functions_ret_user_used.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Check return value for user func
+--SKIPIF--
+<?php if (!extension_loaded("snuffleupagus")) die "skip"; ?>
+--INI--
+sp.configuration_file={PWD}/config/config_disabled_functions_ret_user.ini
+--FILE--
+<?php 
+function qwe() {
+  return "asd";
+}
+echo qwe();
+?>
+--EXPECTF--
+Fatal error: [snuffleupagus][disabled_function] Aborted execution on return of the function 'qwe', because the function returned 'asd', which matched a rule in %a/tests/disabled_functions_ret_user_used.php on line %d


### PR DESCRIPTION
https://github.com/nbs-system/snuffleupagus/issues/169
Matching on user function is working, but when a user function is called and the return value isn't used, `zend_execute->return_value` is `NULL`.