### PR TITLE
match on ret improvments

### DIFF
--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -403,7 +403,7 @@ allow:
   return false;
 }
 
-bool should_drop_on_ret_ht(zval* return_value, const char* function_name,
+bool should_drop_on_ret_ht(const zval* return_value, const char* function_name,
                            const sp_list_node* config, const HashTable* ht,
                            zend_execute_data* execute_data) {
   const sp_list_node* ht_entry = NULL;
@@ -425,7 +425,7 @@ bool should_drop_on_ret_ht(zval* return_value, const char* function_name,
   return ret;
 }
 
-bool should_drop_on_ret(zval* return_value, const sp_list_node* config,
+bool should_drop_on_ret(const zval* return_value, const sp_list_node* config,
                         const char* complete_function_path,
                         zend_execute_data* execute_data) {
   const char* current_filename = zend_get_executed_filename(TSRMLS_C);

--- a/src/sp_disabled_functions.h
+++ b/src/sp_disabled_functions.h
@@ -10,8 +10,9 @@ bool should_disable(zend_execute_data *, const char *, const zend_string *,
 bool should_disable_ht(zend_execute_data *, const char *, const zend_string *,
                        const char *, const sp_list_node *, const HashTable *);
 bool should_drop_on_ret_ht(zval *, const char *, const sp_list_node *config,
-                           const HashTable *);
-bool should_drop_on_ret(zval *, const sp_list_node *config, const char *);
+                           const HashTable *, zend_execute_data *);
+bool should_drop_on_ret(zval *, const sp_list_node *config, const char *,
+                        zend_execute_data *);
 char *get_complete_function_path(zend_execute_data const *const);
 
 #endif /* __SP_DISABLE_FUNCTIONS_H */

--- a/src/sp_disabled_functions.h
+++ b/src/sp_disabled_functions.h
@@ -9,9 +9,9 @@ bool should_disable(zend_execute_data *, const char *, const zend_string *,
                     const char *, const sp_list_node *, const zend_string *);
 bool should_disable_ht(zend_execute_data *, const char *, const zend_string *,
                        const char *, const sp_list_node *, const HashTable *);
-bool should_drop_on_ret_ht(zval *, const char *, const sp_list_node *config,
+bool should_drop_on_ret_ht(const zval *, const char *, const sp_list_node *config,
                            const HashTable *, zend_execute_data *);
-bool should_drop_on_ret(zval *, const sp_list_node *config, const char *,
+bool should_drop_on_ret(const zval *, const sp_list_node *config, const char *,
                         zend_execute_data *);
 char *get_complete_function_path(zend_execute_data const *const);
 

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -151,6 +151,7 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
 
   if (SNUFFLEUPAGUS_G(config).hook_execute) {
     char *function_name = get_complete_function_path(execute_data);
+    zval ret_val;
 
     if (!function_name) {
       orig_execute_ex(execute_data);
@@ -185,23 +186,32 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
       }
     }
 
+    if (EX(return_value) == NULL) {
+      memset(&ret_val, 0, sizeof(ret_val));
+      EX(return_value) = &ret_val;
+    }
+
     orig_execute_ex(execute_data);
 
-    if (EX(return_value) != NULL) {
-      if (UNEXPECTED(
-            true ==
-            should_drop_on_ret_ht(
-              EX(return_value), function_name,
-              SNUFFLEUPAGUS_G(config)
-              .config_disabled_functions_reg_ret->disabled_functions,
-              SNUFFLEUPAGUS_G(config).config_disabled_functions_ret))) {
-        sp_terminate();
-      }
+    if (UNEXPECTED(
+          true ==
+          should_drop_on_ret_ht(
+            EX(return_value), function_name,
+            SNUFFLEUPAGUS_G(config)
+            .config_disabled_functions_reg_ret->disabled_functions,
+            SNUFFLEUPAGUS_G(config).config_disabled_functions_ret,
+            execute_data))) {
+      sp_terminate();
     }
     efree(function_name);
+
+    if (EX(return_value) == &ret_val) {
+      EX(return_value) = NULL;
+    }
   } else {
     orig_execute_ex(execute_data);
   }
+
 }
 
 static void sp_zend_execute_internal(INTERNAL_FUNCTION_PARAMETERS) {

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -186,8 +186,8 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
       }
     }
 
-    // When a return value isn't used, php don't store it in the execute_data.
-    // So we keep it in a local var.
+    // When a function's return value isn't used, php doesn't store it in the execute_data,
+    // so we need to use a local variable to be able to match on it later.
     if (EX(return_value) == NULL) {
       memset(&ret_val, 0, sizeof(ret_val));
       EX(return_value) = &ret_val;

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -186,6 +186,8 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
       }
     }
 
+    // When a return value isn't used, php don't store it in the execute_data.
+    // So we keep it in a local var.
     if (EX(return_value) == NULL) {
       memset(&ret_val, 0, sizeof(ret_val));
       EX(return_value) = &ret_val;

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -151,7 +151,7 @@ static char* zend_string_to_char(const zend_string* zs) {
   return copy;
 }
 
-const zend_string* sp_zval_to_zend_string(zval* zv) {
+const zend_string* sp_zval_to_zend_string(const zval* zv) {
   switch (Z_TYPE_P(zv)) {
     case IS_LONG: {
       char* msg;

--- a/src/sp_utils.h
+++ b/src/sp_utils.h
@@ -46,7 +46,7 @@
 
 void sp_log_msg(char const *feature, int type, const char *fmt, ...);
 int compute_hash(const char *const filename, char *file_hash);
-const zend_string *sp_zval_to_zend_string(zval *);
+const zend_string *sp_zval_to_zend_string(const zval *);
 bool sp_match_value(const zend_string *, const zend_string *, const sp_pcre *);
 bool sp_match_array_key(const zval *, const zend_string *, const sp_pcre *);
 bool sp_match_array_value(const zval *, const zend_string *, const sp_pcre *);

--- a/src/tests/disabled_functions_chain_call_user_func_ret.phpt
+++ b/src/tests/disabled_functions_chain_call_user_func_ret.phpt
@@ -21,6 +21,15 @@ echo one('matching') . "\n";
 echo one('still not matching') . "\n";
 
 ?>
---XFAIL--
 --EXPECTF--
-Match on ret is broken :/
+one
+two
+not matching_one
+one
+two
+
+Warning: [snuffleupagus][disabled_function] Aborted execution on return of the function 'two', because the function returned 'matching_two', which matched a rule in %a/tests/disabled_functions_chain_call_user_func_ret.php on line %d
+matching_one
+one
+two
+still not matching_one

--- a/src/tests/disabled_functions_ret_user.phpt
+++ b/src/tests/disabled_functions_ret_user.phpt
@@ -12,5 +12,5 @@ function qwe() {
 qwe();
 echo 1;
 ?>
---EXPECT--
-1
+--EXPECTF--
+Fatal error: [snuffleupagus][disabled_function] Aborted execution on return of the function 'qwe', because the function returned 'asd', which matched a rule in %a/tests/disabled_functions_ret_user.php on line %d


### PR DESCRIPTION
This pull-requests does two things:

1. Implement matching on calltraces for ret 
2. Implement matching on ret of user functions if the return value is not used.

It should close #144.