### PR TITLE
Fix #241 segfault on 32-bit related to bad protype

### DIFF
--- a/src/php_snuffleupagus.h
+++ b/src/php_snuffleupagus.h
@@ -25,6 +25,11 @@
 #include "zend_string.h"
 #include "zend_extensions.h"
 
+/* Compatibility */
+#if PHP_VERSION_ID < 70200
+typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+#endif
+
 #include "sp_pcre_compat.h"
 #include "sp_list.h"
 #include "sp_tree.h"

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -501,7 +501,7 @@ bool should_drop_on_ret(const zval* return_value, const sp_list_node* config,
 }
 
 ZEND_FUNCTION(check_disabled_function) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
   const char* current_function_name = get_active_function_name(TSRMLS_C);
 
   if (true == should_disable_ht(
@@ -566,7 +566,7 @@ static int hook_functions(HashTable* to_hook_ht, HashTable* hooked_ht) {
 }
 
 ZEND_FUNCTION(eval_blacklist_callback) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
   const char* current_function_name = get_active_function_name(TSRMLS_C);
   zend_string* tmp =
       zend_string_init(current_function_name, strlen(current_function_name), 0);

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -52,7 +52,7 @@ static void random_int_wrapper(INTERNAL_FUNCTION_PARAMETERS) {
 }
 
 PHP_FUNCTION(sp_rand) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
 
   /* call the original `rand` function,
    * since we might no be the only ones to hook it*/
@@ -64,7 +64,7 @@ PHP_FUNCTION(sp_rand) {
 }
 
 PHP_FUNCTION(sp_mt_rand) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
 
   /* call the original `mt_rand` function,
    * since we might no be the only ones to hook it*/

--- a/src/sp_sloppy.c
+++ b/src/sp_sloppy.c
@@ -38,8 +38,8 @@ ZEND_API zend_op_array* sp_compile_file(zend_file_handle* file_handle,
 
 static void array_handler(INTERNAL_FUNCTION_PARAMETERS,
     const char *name, size_t size,
-    void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS)) {
-  void (*handler)(INTERNAL_FUNCTION_PARAMETERS);
+    zif_handler orig_handler) {
+  zif_handler handler;
   zval func_name;
   zval params[3];
   zval *value, *array;

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -3,7 +3,7 @@
 ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
 
 PHP_FUNCTION(sp_serialize) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
 
   /* Call the original `serialize` function. */
   orig_handler = zend_hash_str_find_ptr(
@@ -42,7 +42,7 @@ PHP_FUNCTION(sp_serialize) {
 }
 
 PHP_FUNCTION(sp_unserialize) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
 
   char *buf = NULL;
   char *serialized_str = NULL;

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -320,7 +320,7 @@ bool sp_match_array_value(const zval* arr, const zend_string* to_match,
 }
 
 int hook_function(const char* original_name, HashTable* hook_table,
-                  void (*new_function)(INTERNAL_FUNCTION_PARAMETERS)) {
+                  zif_handler new_function) {
   zend_internal_function* func;
   bool ret = FAILURE;
 
@@ -363,7 +363,7 @@ int hook_function(const char* original_name, HashTable* hook_table,
 }
 
 int hook_regexp(const sp_pcre* regexp, HashTable* hook_table,
-                void (*new_function)(INTERNAL_FUNCTION_PARAMETERS)) {
+                zif_handler new_function) {
   zend_string* key;
 
   ZEND_HASH_FOREACH_STR_KEY(CG(function_table), key)

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -287,7 +287,7 @@ bool sp_match_array_key(const zval* zv, const zend_string* to_match,
       }
     } else {
       char* idx_str = NULL;
-      spprintf(&idx_str, 0, "%lu", idx);
+      spprintf(&idx_str, 0, ZEND_ULONG_FMT, idx);
       zend_string* tmp = zend_string_init(idx_str, strlen(idx_str), 0);
       if (sp_match_value(tmp, to_match, rx)) {
         efree(idx_str);

--- a/src/sp_utils.h
+++ b/src/sp_utils.h
@@ -54,10 +54,8 @@ void sp_log_disable(const char *restrict, const char *restrict,
                     const zend_string *restrict, const sp_disabled_function *);
 void sp_log_disable_ret(const char *restrict, const zend_string *restrict,
                         const sp_disabled_function *);
-int hook_function(const char *, HashTable *,
-                  void (*)(INTERNAL_FUNCTION_PARAMETERS));
-int hook_regexp(const sp_pcre *, HashTable *,
-                void (*)(INTERNAL_FUNCTION_PARAMETERS));
+int hook_function(const char *, HashTable *, zif_handler);
+int hook_regexp(const sp_pcre *, HashTable *, zif_handler);
 bool check_is_in_eval_whitelist(const zend_string *const function_name);
 int sp_log_request(const zend_string *folder, const zend_string *text_repr,
                    char *from);

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -45,7 +45,7 @@ void sp_disable_wrapper() {
 }
 
 PHP_FUNCTION(sp_stream_wrapper_register) {
-  void (*orig_handler)(INTERNAL_FUNCTION_PARAMETERS);
+  zif_handler orig_handler;
   zend_string *protocol_name = NULL;
 
   ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_QUIET, 2, EX_NUM_ARGS());


### PR DESCRIPTION
the zif_handler type was introduced in 7.2, and have changed in 7.3

* 7.2: typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
* 7.3: typedef void (ZEND_FASTCALL *zif_handler)(INTERNAL_FUNCTION_PARAMETERS);

New prototype raise build warning on 32-bit

```C
/builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_wrapper.c: In function 'hook_stream_wrappers':
/usr/include/php/Zend/zend_API.h:61:23: warning: passing argument 3 of 'hook_function' from incompatible pointer type [-Wincompatible-pointer-types]
 #define ZEND_FN(name) zif_##name
                       ^~~~
/builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_utils.h:26:61: note: in definition of macro 'HOOK_FUNCTION'
   hook_function(original_name, SNUFFLEUPAGUS_G(hook_table), new_function)
                                                             ^~~~~~~~~~~~
/usr/include/php/main/php.h:406:20: note: in expansion of macro 'ZEND_FN'
 #define PHP_FN     ZEND_FN
                    ^~~~~~~
/builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_wrapper.c:67:17: note: in expansion of macro 'PHP_FN'
                 PHP_FN(sp_stream_wrapper_register));
                 ^~~~~~
/builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_utils.h:58:19: note: expected 'void (*)(zend_execute_data *, zval *)' {aka 'void (*)(struct _zend_execute_data *, struct _zval_struct *)'} but argument is of type 'void (__attribute__((fastcall)) *)(zend_execute_data *, zval *)'
                   void (*)(INTERNAL_FUNCTION_PARAMETERS));
  
```                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This patch fix build and test suite.
