### PR TITLE
add const attribute, added in 7.3

### DIFF
--- a/src/sp_session.c
+++ b/src/sp_session.c
@@ -15,7 +15,11 @@ static php_ps_globals *session_globals = NULL;
 #endif
 
 static ps_module *s_module;
+#if PHP_VERSION_ID < 70300
 static ps_module *s_original_mod;
+#else
+static const ps_module *s_original_mod;
+#endif
 static int (*old_s_read)(PS_READ_ARGS);
 static int (*old_s_write)(PS_WRITE_ARGS);
 static int (*previous_sessionRINIT)(INIT_FUNC_ARGS) = NULL;
@@ -56,7 +60,11 @@ static int sp_hook_s_write(PS_WRITE_ARGS) {
 }
 
 static void sp_hook_session_module() {
+#if PHP_VERSION_ID < 70300
   ps_module *old_mod = SESSION_G(mod);
+#else
+  const ps_module *old_mod = SESSION_G(mod);
+#endif
   ps_module *mod;
 
   if (old_mod == NULL || s_module == old_mod) {


### PR DESCRIPTION
This is the last warning encountered during the build 
```
BUILDSTDERR: /builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_session.c: In function 'sp_hook_session_module':
BUILDSTDERR: /builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_session.c:14:22: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
BUILDSTDERR:  #define SESSION_G(v) (ps_globals.v)
BUILDSTDERR:                       ^
BUILDSTDERR: /builddir/build/BUILD/snuffleupagus-721adb907fa4636693695024d3ed7ca8602db261/src/sp_session.c:59:24: note: in expansion of macro 'SESSION_G'
BUILDSTDERR:    ps_module *old_mod = SESSION_G(mod);
BUILDSTDERR:                         ^~~~~~~~~

```
\o/