### PR TITLE
Don't check the return values of functions that might not return

### DIFF
--- a/src/sp_disabled_functions.h
+++ b/src/sp_disabled_functions.h
@@ -5,15 +5,11 @@ extern zend_write_func_t zend_write_default;
 
 int hook_disabled_functions();
 int hook_echo(const char *, size_t);
-bool should_disable(zend_execute_data *, const char *, const zend_string *,
-                    const char *, const sp_list_node *, const zend_string *);
-bool should_disable_ht(zend_execute_data *, const char *, const zend_string *,
+void should_disable_ht(zend_execute_data *, const char *, const zend_string *,
                        const char *, const sp_list_node *, const HashTable *);
-bool should_drop_on_ret_ht(const zval *, const char *,
+void should_drop_on_ret_ht(const zval *, const char *,
                            const sp_list_node *config, const HashTable *,
                            zend_execute_data *);
-bool should_drop_on_ret(const zval *, const sp_list_node *config, const char *,
-                        zend_execute_data *);
 char *get_complete_function_path(zend_execute_data const *const);
 
 #endif /* __SP_DISABLE_FUNCTIONS_H */

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -49,13 +49,10 @@ inline static void is_builtin_matching(
     return;
   }
 
-  if (true ==
-      should_disable_ht(EG(current_execute_data), function_name, param_value,
-                        param_name,
-                        SNUFFLEUPAGUS_G(config)
-                            .config_disabled_functions_reg->disabled_functions,
-                        ht)) {
-  }
+  should_disable_ht(
+      EG(current_execute_data), function_name, param_value, param_name,
+      SNUFFLEUPAGUS_G(config).config_disabled_functions_reg->disabled_functions,
+      ht);
 }
 
 static void ZEND_HOT
@@ -168,11 +165,9 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
         !execute_data->prev_execute_data->func ||
         !ZEND_USER_CODE(execute_data->prev_execute_data->func->type) ||
         !execute_data->prev_execute_data->opline) {
-      if (UNEXPECTED(true == should_disable_ht(execute_data, function_name,
-                                               NULL, NULL,
-                                               config_disabled_functions_reg,
-                                               config_disabled_functions))) {
-      }
+      should_disable_ht(execute_data, function_name, NULL, NULL,
+                        config_disabled_functions_reg,
+                        config_disabled_functions);
     } else if ((execute_data->prev_execute_data->opline->opcode ==
                     ZEND_DO_FCALL ||
                 execute_data->prev_execute_data->opline->opcode ==
@@ -181,11 +176,9 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
                     ZEND_DO_ICALL ||
                 execute_data->prev_execute_data->opline->opcode ==
                     ZEND_DO_FCALL_BY_NAME)) {
-      if (UNEXPECTED(true == should_disable_ht(execute_data, function_name,
-                                               NULL, NULL,
-                                               config_disabled_functions_reg,
-                                               config_disabled_functions))) {
-      }
+      should_disable_ht(execute_data, function_name, NULL, NULL,
+                        config_disabled_functions_reg,
+                        config_disabled_functions);
     }
 
     // When a function's return value isn't used, php doesn't store it in the
@@ -198,15 +191,11 @@ static void sp_execute_ex(zend_execute_data *execute_data) {
 
     orig_execute_ex(execute_data);
 
-    if (UNEXPECTED(
-            true ==
-            should_drop_on_ret_ht(
-                EX(return_value), function_name,
-                SNUFFLEUPAGUS_G(config)
-                    .config_disabled_functions_reg_ret->disabled_functions,
-                SNUFFLEUPAGUS_G(config).config_disabled_functions_ret,
-                execute_data))) {
-    }
+    should_drop_on_ret_ht(
+        EX(return_value), function_name,
+        SNUFFLEUPAGUS_G(config)
+            .config_disabled_functions_reg_ret->disabled_functions,
+        SNUFFLEUPAGUS_G(config).config_disabled_functions_ret, execute_data);
     efree(function_name);
 
     if (EX(return_value) == &ret_val) {


### PR DESCRIPTION
This is due to our modifications to the logging system