### PR TITLE
Improve simulation mode for session cookies

### DIFF
--- a/src/sp_session.c
+++ b/src/sp_session.c
@@ -30,19 +30,18 @@ static int sp_hook_s_read(PS_READ_ARGS) {
   const sp_config_session *config_session =
       SNUFFLEUPAGUS_G(config).config_session;
 
-  if (r == SUCCESS && config_session->encrypt && val != NULL && *val != NULL &&
-      ZSTR_LEN(*val)) {
+  if ((NULL == val) || (NULL == *val) || (0 == ZSTR_LEN(*val))) {
+    return r;
+  }
+
+  if (r == SUCCESS && config_session->encrypt) {
     zend_string *orig_val = *val;
     zval val_zval;
     ZVAL_PSTRINGL(&val_zval, ZSTR_VAL(*val), ZSTR_LEN(*val));
 
     int ret = decrypt_zval(&val_zval, config_session->simulation, NULL);
-    if (0 != ret) {
-      if (config_session->simulation) {
-        return ret;
-      } else {
-        zend_bailout();
-      }
+    if (ZEND_HASH_APPLY_KEEP != ret) {
+      zend_bailout();
     }
 
     *val = zend_string_dup(val_zval.value.str, 0);

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -348,7 +348,7 @@ int hook_function(const char* original_name, HashTable* hook_table,
 
   if (0 == strncmp(original_name, "mb_", 3) && !CG(multibyte)) {
     if (zend_hash_str_find(CG(function_table),
-          VAR_AND_LEN(original_name + 3))) {
+                           VAR_AND_LEN(original_name + 3))) {
       return hook_function(original_name + 3, hook_table, new_function);
     }
   } else if (CG(multibyte)) {


### PR DESCRIPTION
Since decrypt_zval doesn't provide a way to tell apart failed and successful decryptions
when used in simulation mode, we'll have to restore the original value if something goes wrong, because crypto_secretbox_open might modify the value.