### PR TITLE
use php script, get rid of python for test suite

### DIFF
--- a/scripts/upload_validation.php
+++ b/scripts/upload_validation.php
@@ -16,7 +16,7 @@ function check($filename) {
 		"-d", "vld.col_sep=@",
 		"-d", "log_errors=0",
 		"-d", "error_log=/dev/null",
-		$filename,
+		escapeshellarg($filename),
 		'2>&1',
 		];
 	exec(implode(' ', $cmd), $out, $ret);

--- a/scripts/upload_validation.php
+++ b/scripts/upload_validation.php
@@ -1,0 +1,45 @@
+#!/usr/bin/env php
+<?php
+
+function check($filename) {
+
+	$whitelist = ['ECHO', 'RETURN', 'PHP', 'NOP'];
+
+	$out = [];
+	$ret = 0;
+	$cmd = [
+		PHP_BINARY,
+		"-d", "vld.active=1",
+		"-d", "vld.execute=0",
+		"-d", "extension=vld.so",
+		"-d", "vld.format=1",
+		"-d", "vld.col_sep=@",
+		"-d", "log_errors=0",
+		"-d", "error_log=/dev/null",
+		$filename,
+		'2>&1',
+		];
+	exec(implode(' ', $cmd), $out, $ret);
+	if ($ret) {
+        printf("Error: %d\n", $ret);
+		return 2;
+	}
+	foreach($out as $line) {
+		$sp = explode('@', $line);
+		if (count($sp) < 5) {
+			continue;
+		}
+		$opcode = $sp[4]; // # ,line, #, EIO, op, fetch, ext, return, operands
+		if ($opcode && !in_array($opcode, $whitelist)) {
+			printf("Upload_validation: Found an opcode: %s\n", $opcode);
+			return 1;
+		}
+	}
+	return 0;
+}
+
+if ($_SERVER['argc'] != 2) {
+	die("Usage: {$_SERVER['argv']['0']} file_to_test.php\n");
+}
+exit(check($_SERVER['argv']['1']));
+

--- a/src/tests/config/upload_validation_real.ini
+++ b/src/tests/config/upload_validation_real.ini
@@ -1,1 +1,1 @@
-sp.upload_validation.script("../scripts/upload_validation.py").enable();
+sp.upload_validation.script("../scripts/upload_validation.php").enable();


### PR DESCRIPTION
the upload_validation.py is problematic, we can"t run test suite because of its hardcoded path to `/usr/bin/python`, especially on distribution with only "python3" (e.g. RHEL-8)

Having same feature written in PHP seems simpler for a PHP extension.

Of course a simple `sed -e "s:/usr/bin/python:/usr/bin/env python3:"` can do the trick, but won't work on distro with only python2 (e.g. RHEL-6)