### PR TITLE
Remove full stop from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<h4 align="center">Security module for php7 - Killing bugclasses and virtual-patching the rest!.</h4>
+<h4 align="center">Security module for php7 - Killing bugclasses and virtual-patching the rest!</h4>
 
 <p align="center">
   <a href="https://travis-ci.org/nbs-system/snuffleupagus">


### PR DESCRIPTION
Please consider removing some `align="center"` attributes. It looks very artistic.