### PR TITLE
Depend on shlibs in Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Vcs-Git: https://github.com/nbs-system/snuffleupagus
 
 Package: snuffleupagus
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Hardening for your php7 stack
 	Snuffleupagus is cool


### PR DESCRIPTION
lintian says:

> W: snuffleupagus: missing-depends-line