### PR TITLE
Fix warning on FreeBSD

### DIFF
--- a/src/sp_config.c
+++ b/src/sp_config.c
@@ -1,4 +1,7 @@
 #include <errno.h>
+#if defined(__FreeBSD__)
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Fix warning on FreeBSD:
snuffleupagus/src/sp_config.c:193:10: warning: implicit declaration of function 'getline' is invalid in C99 [-Wimplicit-function-declaration]
  while (getline(&lineptr, &n, fd) > 0) {
         ^
1 warning generated.