### PR TITLE
this test requires openssl ext

### DIFF
--- a/src/tests/stream_wrapper/stream_wrapper.phpt
+++ b/src/tests/stream_wrapper/stream_wrapper.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Stream wrapper
 --SKIPIF--
-<?php if (!extension_loaded("snuffleupagus")) print "skip"; ?>
+<?php
+if (!extension_loaded("snuffleupagus")) print "skip snuffleupagus extension missing";
+if (!extension_loaded("openssl")) print "skip openssl extension missing";
+?>
 --INI--
 sp.configuration_file={PWD}/config/config_stream_wrapper.ini
 --FILE--


### PR DESCRIPTION
This test fails when run with a default build of PHP  (only "./configure", no option)

```
009+ Warning: file_get_contents(http://qweqwezxc): failed to open stream: No such file or directory in /work/GIT/pecl-and-ext/snuffleupagus/src/tests/stream_wrapper/stream_wrapper.php on line 2
009- Warning: file_get_contents(): php_network_getaddresses: getaddrinfo failed: %s
011+ Warning: file_get_contents(): Unable to find the wrapper "https" - did you forget to enable it when you configured PHP? in /work/GIT/pecl-and-ext/snuffleupagus/src/tests/stream_wrapper/stream_wrapper.php on line 3
012+ 
013+ Warning: file_get_contents(https://qweqwezxc): failed to open stream: No such file or directory in /work/GIT/pecl-and-ext/snuffleupagus/src/tests/stream_wrapper/stream_wrapper.php on line 3
011- Warning: file_get_contents(https://qweqwezxc): failed to open stream: php_network_getaddresses: getaddrinfo failed: %s[remi@builder src (master)]$ ^C

```