### PR TITLE
fix snufflepagus_globals linking issues and one mac compatibility issue

### DIFF
--- a/src/php_snuffleupagus.h
+++ b/src/php_snuffleupagus.h
@@ -99,6 +99,7 @@ HashTable *sp_internal_functions_hook;
 HashTable *sp_eval_blacklist_functions_hook;
 ZEND_END_MODULE_GLOBALS(snuffleupagus)
 
+ZEND_EXTERN_MODULE_GLOBALS(snuffleupagus)
 #define SNUFFLEUPAGUS_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(snuffleupagus, v)
 
 #if defined(ZTS) && defined(COMPILE_DL_SNUFFLEUPAGUS)

--- a/src/sp_config.c
+++ b/src/sp_config.c
@@ -4,8 +4,6 @@
 
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 size_t sp_line_no;
 
 sp_config_tokens const sp_func[] = {

--- a/src/sp_config_keywords.c
+++ b/src/sp_config_keywords.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static int parse_enable(char *line, bool *restrict retval,
                         bool *restrict simulation) {
   bool enable = false, disable = false;

--- a/src/sp_config_utils.c
+++ b/src/sp_config_utils.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-// size_t sp_line_no;
-
 int parse_keywords(sp_config_functions *funcs, char *line) {
   int value_len = 0;
   const char *original_line = line;

--- a/src/sp_config_utils.c
+++ b/src/sp_config_utils.c
@@ -1,6 +1,6 @@
 #include "php_snuffleupagus.h"
 
-size_t sp_line_no;
+// size_t sp_line_no;
 
 int parse_keywords(sp_config_functions *funcs, char *line) {
   int value_len = 0;

--- a/src/sp_cookie_encryption.c
+++ b/src/sp_cookie_encryption.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static inline const sp_cookie *sp_lookup_cookie_config(const zend_string *key) {
   const sp_list_node *it = SNUFFLEUPAGUS_G(config).config_cookie->cookies;
 

--- a/src/sp_crypt.c
+++ b/src/sp_crypt.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 void generate_key(unsigned char *key) {
   PHP_SHA256_CTX ctx;
   const char *user_agent = getenv("HTTP_USER_AGENT");

--- a/src/sp_disable_xxe.c
+++ b/src/sp_disable_xxe.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 PHP_FUNCTION(sp_libxml_disable_entity_loader) { RETURN_TRUE; }
 
 int hook_libxml_disable_entity_loader() {

--- a/src/sp_disabled_functions.c
+++ b/src/sp_disabled_functions.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static void should_disable(zend_execute_data* execute_data,
                            const char* complete_function_path,
                            const zend_string* builtin_param,

--- a/src/sp_execute.c
+++ b/src/sp_execute.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static void (*orig_execute_ex)(zend_execute_data *execute_data) = NULL;
 static void (*orig_zend_execute_internal)(zend_execute_data *execute_data,
                                           zval *return_value) = NULL;

--- a/src/sp_harden_rand.c
+++ b/src/sp_harden_rand.c
@@ -2,8 +2,6 @@
 
 extern ZEND_API zend_class_entry *zend_ce_error;
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 /* This function is needed because `rand` and `mt_rand` parameters
  * are optional, while the ones from `random_int` aren't. */
 static void random_int_wrapper(INTERNAL_FUNCTION_PARAMETERS) {

--- a/src/sp_network_utils.c
+++ b/src/sp_network_utils.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static inline bool cidr4_match(const struct in_addr addr,
                                const struct in_addr net, uint8_t bits);
 static inline bool cidr6_match(const struct in6_addr address,
@@ -19,7 +17,7 @@ static inline bool cidr4_match(const struct in_addr addr,
 
 static inline bool cidr6_match(const struct in6_addr address,
                                const struct in6_addr network, uint8_t bits) {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
   const uint32_t *a = address.__u6_addr.__u6_addr32;
   const uint32_t *n = network.__u6_addr.__u6_addr32;
 #else

--- a/src/sp_session.c
+++ b/src/sp_session.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 #if (HAVE_PHP_SESSION && !defined(COMPILE_DL_SESSION))
 
 #ifdef ZTS

--- a/src/sp_sloppy.c
+++ b/src/sp_sloppy.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 ZEND_API zend_op_array* (*orig_zend_compile_file)(zend_file_handle* file_handle,
                                                   int type) = NULL;
 ZEND_API zend_op_array* (*orig_zend_compile_string)(zval* source_string,

--- a/src/sp_unserialize.c
+++ b/src/sp_unserialize.c
@@ -1,6 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
 
 PHP_FUNCTION(sp_serialize) {
   zif_handler orig_handler;

--- a/src/sp_upload_validation.c
+++ b/src/sp_upload_validation.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 int (*sp_rfc1867_orig_callback)(unsigned int event, void *event_data,
                                 void **extra);
 int sp_rfc1867_callback(unsigned int event, void *event_data, void **extra);

--- a/src/sp_utils.c
+++ b/src/sp_utils.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 bool sp_zend_string_equals(const zend_string* s1, const zend_string* s2) {
   // We can't use `zend_string_equals` here because it doesn't work on
   // `const` zend_string.

--- a/src/sp_wrapper.c
+++ b/src/sp_wrapper.c
@@ -1,7 +1,5 @@
 #include "php_snuffleupagus.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 static bool wrapper_is_whitelisted(const zend_string *zs) {
   const sp_list_node *list = SNUFFLEUPAGUS_G(config).config_wrapper->whitelist;
 

--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -3,8 +3,6 @@ we're using the one from PHP.*/
 #include "php_snuffleupagus.h"
 #include "ext/standard/php_random.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(snuffleupagus)
-
 void randombytes(unsigned char *x, unsigned long long xlen) {
   assert(SIZE_MAX >= ULLONG_MAX);  // max(size_t) > max(ull) ?
   php_random_bytes(x, xlen, 1);


### PR DESCRIPTION
removed duplicate snuffleupagus_global declarations. otherwise:
```
duplicate symbol _snuffleupagus_globals in:
    .libs/snuffleupagus.o
    .libs/sp_config.o
duplicate symbol _snuffleupagus_globals in:
    .libs/snuffleupagus.o
    .libs/sp_harden_rand.o
```
also cleared up one duplicate instance of size_t sp_line_no and one mac compatibility issue